### PR TITLE
fix: Improve tmux compatibility

### DIFF
--- a/src/theme.sh
+++ b/src/theme.sh
@@ -46,7 +46,9 @@ tmux set-option -g status-style "bg=${status_bar_bg},fg=${PALLETE[white]}"
 
 # border color
 tmux set-option -g pane-active-border-style "fg=$border_style_active_pane"
-tmux set-option -g pane-border-style "#{?pane_synchronized,fg=$border_style_active_pane,fg=$border_style_inactive_pane}"
+if ! tmux set-option -g pane-border-style "#{?pane_synchronized,fg=$border_style_active_pane,fg=$border_style_inactive_pane}" &>/dev/null; then
+  tmux set-option -g pane-border-style "fg=$border_style_active_pane,fg=$border_style_inactive_pane"
+fi
 
 ### Left side
 tmux set-option -g status-left "$(generate_left_side_string)"


### PR DESCRIPTION
That PR is especially amusing to me because I introduced that line a year ago. And now I have to fix it. I work with older versions of tmux on a daily basis that don’t support the `#{?condition,foo,bar}` syntax, so I occasionally have to make that change manually. It's the only change needed for the theme to work with tmux 2.7 and possibly earlier versions.