### PR TITLE
feat(external): expand #{...} tmux variables inside shell commands

### DIFF
--- a/src/render_plugins.sh
+++ b/src/render_plugins.sh
@@ -113,13 +113,21 @@ _string_hash() {
 
 # Execute shell command from content string (DRY - used by external plugins)
 # Supports: #(command), $(command), #{tmux_var}
+# Also expands #{...} inside $(command) and #(command) before execution
 # Returns: executed content or empty string
 _execute_content_command() {
     local content="$1"
+    local cmd
     if [[ "$content" =~ ^\#\(.*\)$ ]]; then
-        eval "${content:2:-1}" 2>/dev/null || printf ''
+        cmd="${content:2:-1}"
+        # Expand #{...} inside command first
+        [[ "$cmd" == *'#{'*'}'* ]] && cmd=$(tmux display-message -p "$cmd" 2>/dev/null)
+        eval "$cmd" 2>/dev/null || printf ''
     elif [[ "$content" =~ ^\$\(.*\)$ ]]; then
-        eval "${content:2:-1}" 2>/dev/null || printf ''
+        cmd="${content:2:-1}"
+        # Expand #{...} inside command first
+        [[ "$cmd" == *'#{'*'}'* ]] && cmd=$(tmux display-message -p "$cmd" 2>/dev/null)
+        eval "$cmd" 2>/dev/null || printf ''
     elif [[ "$content" == *'#{'*'}'* ]]; then
         tmux display-message -p "$content" 2>/dev/null || printf ''
     else


### PR DESCRIPTION
## Summary

This PR enables combining tmux format variables (`#{...}`) with shell commands (`$(...)` or `#(...)`) in external plugins.

### Problem

Previously, external plugins could use either:
- Shell commands: `external(|$(my-script)|accent|accent|0)`
- Tmux variables: `external(|#{pane_current_path}|accent|accent|0)`

But not both together. This made it impossible to pass tmux context as arguments to custom scripts.

### Solution

Now `#{...}` variables inside `$(command)` and `#(command)` are expanded via `tmux display-message -p` before the shell command executes:

```bash
# This now works!
external(|$(my-script #{pane_current_path})|accent|accent|0)
external(|$(echo #{session_name}:#{window_index})|info|info|0)
```

### Use Case

This is useful when you want to:
- Pass the current pane's working directory to a custom formatting script
- Include session/window/pane information in script arguments
- Build dynamic content that combines tmux state with custom processing

Without this change, scripts would need to call `tmux display-message` internally, which returns server-wide state instead of the specific pane's context when called from status bar commands.

## Test plan

- [x] Tested with custom scripts receiving `#{pane_current_path}` as argument
- [x] Verified per-pane context is correctly passed (each pane shows its own data)
- [x] Backward compatible - existing configurations work unchanged