### PR TITLE
fix: correct spacing for the first window

### DIFF
--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -131,11 +131,15 @@ _windows_build_separator() {
         # Skip first window - compositor handles edge separator
         # Use #{base-index} to support both base-index=0 and base-index=1
         local not_first='#{?#{!=:#{window_index},#{base-index}},'
-        if [[ "$side" == "left" || "$side" == "center" ]]; then
+        if [[ "$side" == "left" ]]; then
             # Left side ▶: gap → window
             # ▶: fg=gap (left), bg=window (right)
+            printf '#[fg=%s#,bg=%s]%s' "$spacing_fg" "$index_bg" "$_W_SEP_CHAR"
+        elif [[ "$side" == "center" ]]; then
+            # Center side ▶: gap → window
+            # ▶: fg=gap (left), bg=window (right)
             printf '%s#[fg=%s#,bg=%s]%s,}' "$not_first" "$spacing_fg" "$index_bg" "$_W_SEP_CHAR"
-        else
+        elif [[ "$side" == "right" ]]; then
             # Right side ◀: gap → window
             # ◀: fg=window (right), bg=gap (left)
             printf '%s#[fg=%s#,bg=%s]%s,}' "$not_first" "$index_bg" "$spacing_fg" "$_W_SEP_CHAR"


### PR DESCRIPTION
This fixes the spacing issue in front of the first window when the windows are on the left side. I don’t believe the lack of proper spacing between the session and the first window is intentional, as it looks off to me:
<img width="353" height="28" alt="image" src="https://github.com/user-attachments/assets/ea95f4c0-0324-48f9-8cc2-798e35400c24" />

Config:
```sh
# tested with 0 and 1
set -g base-index 1

set -g @powerkit_theme 'tokyo-night'
set -g @powerkit_theme_variant 'night'

set -g @powerkit_status_position 'bottom'
set -g @powerkit_elements_spacing 'windows'

# default
#set -g @powerkit_status_order "session,plugins"
```

The issue does not occur when spacing is disabled:
```sh
set -g @powerkit_elements_spacing 'false'
```
<img width="342" height="30" alt="image" src="https://github.com/user-attachments/assets/b8fca1d4-8be0-4db4-8cce-54ad5566323b" />

---

After the fix:
<img width="363" height="31" alt="image" src="https://github.com/user-attachments/assets/cf75be62-f134-4a8d-91ad-70a099b325a2" />


It also works with custom separators:
<img width="367" height="32" alt="image" src="https://github.com/user-attachments/assets/efa94d3e-9d35-4799-b86d-4c03659b292e" />
<img width="357" height="29" alt="image" src="https://github.com/user-attachments/assets/2180a11e-1407-4e00-ab03-cfee1aa5759d" />
