### PR TITLE
docs(README): typo at Quick Theme Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Plus **Monokai**, **Cobalt2**, **SynthWave '84**, **Horizon**, **Iceberg**, **Sn
 
 ```bash
 # Tokyo Night - Night variant
-set -g @powerkit_theme "catppuccin"
-set -g @powerkit_theme_variant "mocha"
+set -g @powerkit_theme "tokyo-night"
+set -g @powerkit_theme_variant "night"
 
 # Catppuccin - Mocha variant
 set -g @powerkit_theme "catppuccin"


### PR DESCRIPTION
comment says for tokyonight - night but in-line code was for catppuccin
- mocah