### PR TITLE
fix(keybindings): correct keybindings viewer

### DIFF
--- a/src/helpers/keybindings_viewer.sh
+++ b/src/helpers/keybindings_viewer.sh
@@ -71,7 +71,7 @@ format_key() {
 
 extract_plugin_from_path() {
     local path="$1"
-    [[ "$path" =~ /plugins/([^/]+)/ ]] && printf '%s' "${BASH_REMATCH[1]}" || printf ''
+    [[ "$path" =~ /plugins/([^/\'[:space:]]+) ]] && printf '%s' "${BASH_REMATCH[1]}" || printf ''
 }
 
 print_keybindings() {
@@ -89,9 +89,9 @@ print_keybindings() {
 
         # Parse line more efficiently using bash regex
         # Format: bind-key -T prefix <key> <command...>
-        if [[ "$line" =~ ^bind-key[[:space:]]+-T[[:space:]]+prefix[[:space:]]+([^[:space:]]+)[[:space:]]+(.+)$ ]]; then
-            local key="${BASH_REMATCH[1]}"
-            local cmd="${BASH_REMATCH[2]}"
+        if [[ "$line" =~ ^bind-key([[:space:]]+-[[:alpha:]]+)*[[:space:]]+-T[[:space:]]+prefix[[:space:]]+([^[:space:]]+)[[:space:]]+(.+)$ ]]; then
+            local key="${BASH_REMATCH[2]}"
+            local cmd="${BASH_REMATCH[3]}"
             local plugin
 
             plugin=$(extract_plugin_from_path "$cmd")


### PR DESCRIPTION
- The first issue was that the regular expression in the `print_keybindings()` function did not capture lines with flags placed between `bind-key` and `-T`:
```sh
❯ tmux list-keys -T prefix | grep -vE "bind-key[[:space:]]+-T"
bind-key -r -T prefix DC      refresh-client -c
bind-key -r -T prefix Up      select-pane -U
bind-key -r -T prefix Down    select-pane -D
bind-key -r -T prefix Left    select-pane -L
bind-key -r -T prefix Right   select-pane -R
bind-key -r -T prefix M-Up    resize-pane -U 5
bind-key -r -T prefix M-Down  resize-pane -D 5
bind-key -r -T prefix M-Left  resize-pane -L 5
bind-key -r -T prefix M-Right resize-pane -R 5
bind-key -r -T prefix C-Up    resize-pane -U
bind-key -r -T prefix C-Down  resize-pane -D
bind-key -r -T prefix C-Left  resize-pane -L
bind-key -r -T prefix C-Right resize-pane -R
bind-key -r -T prefix S-Up    refresh-client -U 10
bind-key -r -T prefix S-Down  refresh-client -D 10
bind-key -r -T prefix S-Left  refresh-client -L 10
bind-key -r -T prefix S-Right refresh-client -R 10
❯
```

- The second issue was with the regular expression in the `extract_plugin_from_path()` function: it captures the plugin from `/plugins/tmux-powerkit/` but not from `/plugins/tmux-powerkit'`.

Before:
<img width="1566" height="714" alt="image" src="https://github.com/user-attachments/assets/c4ae043f-75e4-4308-9030-d7b9b0dfd1d1" />


After:
<img width="1560" height="715" alt="image" src="https://github.com/user-attachments/assets/03986bf7-e678-4c6f-ae90-5eba8ce31c0e" />
