### PR TITLE
feat: Highlight all pane borders when synchronized

### DIFF
--- a/src/contract/pane_contract.sh
+++ b/src/contract/pane_contract.sh
@@ -362,15 +362,13 @@ pane_border_color() {
 }
 
 # Build pane border style string
-# Usage: pane_border_style "active|inactive|sync"
-# Returns:
-#  "fg=COLOR" if type is "active|inactive"
-#  "#{?pane_synchronized,fg=ACTIVE_COLOR,fg=INACTIVE_COLOR}" if type is "sync"
+# Usage: pane_border_style "active|inactive"
+# Returns: "fg=COLOR"
 pane_border_style() {
     local type="${1:-inactive}"
-    if [[ "$type" =~ ^(in)?active$ ]]; then
+    if [[ "$type" == "active" ]]; then
         printf 'fg=%s' "$(pane_border_color "$type")"
-    elif [[ "$type" == "sync" ]]; then
+    elif [[ "$type" == "inactive" ]]; then
         printf '#{?pane_synchronized,fg=%s,fg=%s}' "$(pane_border_color "active")" "$(pane_border_color "inactive")"
     fi
 }
@@ -471,7 +469,7 @@ pane_configure() {
     log_debug "pane" "Configuring panes"
 
     # Border styles
-    tmux set-option -g pane-border-style "$(pane_border_style "sync")"
+    tmux set-option -g pane-border-style "$(pane_border_style "inactive")"
     tmux set-option -g pane-active-border-style "$(pane_border_style "active")"
 
     # Border lines (tmux 3.2+)


### PR DESCRIPTION
In response to https://github.com/fabioluciano/tmux-powerkit/issues/167

When panes are synchronized, all pane borders are highlighted using the ‘active’ color. It’s a bit hacky, but I had a fixed amount of time to work on this. Maybe in the future we could add a toggle to switch it on or off.