### PR TITLE
fix(windows): add left padding to window tab content

### DIFF
--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -272,10 +272,10 @@ _windows_build_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
+        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}] $(window_get_index_display)"
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
-    format+="#[fg=${content_fg},bg=${content_bg}${style_attr}]${icon_conditional} ${window_title} "
+    format+="#[fg=${content_fg},bg=${content_bg}${style_attr}] ${icon_conditional} ${window_title} "
     format+=$(_windows_build_spacing "$side" "$content_bg")
     format+="#[norange]"
 
@@ -328,10 +328,10 @@ _windows_build_current_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
+        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}] $(window_get_index_display)"
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
-    format+="#[fg=${content_fg},bg=${content_bg}${style_attr}]${icon_conditional} ${window_title} $(pane_sync_format)"
+    format+="#[fg=${content_fg},bg=${content_bg}${style_attr}] ${icon_conditional} ${window_title} $(pane_sync_format)"
     format+=$(_windows_build_spacing "$side" "$content_bg")
     format+="#[norange]"
 


### PR DESCRIPTION
## Problem

Window tab content (both active and inactive) renders flush against the left separator glyphs with zero padding. This is most noticeable with curved separator styles like `rounded`, where the index number or icon sits directly against the separator character with no breathing room.

Happens when `@powerkit_elements_spacing` is `false` (the default), so this affects most users out of the box.

**Affected areas:**
- Index number section in `_windows_build_format()` and `_windows_build_current_format()`
- Icon/title section when index is hidden (the content section becomes the first thing after the separator)

## Environment

- **tmux-powerkit**: v5.17.0
- **tmux**: 3.6a
- **OS**: macOS (Darwin 24.6.0)

## Fix

Moved the padding space from trailing to leading on the index section, and added a leading space to the content section. This way the text always has a space between it and the preceding separator glyph, regardless of whether the index is shown or hidden.

Specifically, in both `_windows_build_format()` (inactive) and `_windows_build_current_format()` (active):

**Index section** — space moved from after the index to before it:
```
# before
]$(window_get_index_display) "
# after
] $(window_get_index_display)"
```

**Content section** — leading space added:
```
# before
]${icon_conditional} ${window_title} "
# after
] ${icon_conditional} ${window_title} "
```

The trailing space on the content section is preserved since it provides the right-side padding before the next separator or spacing element.