### PR TITLE
feat(renderer): use luminance-based contrast for text readability

### DIFF
--- a/src/renderer/color_resolver.sh
+++ b/src/renderer/color_resolver.sh
@@ -91,6 +91,23 @@ resolve_color() {
 }
 
 # =============================================================================
+# Contrast Utilities
+# =============================================================================
+
+# Get a black or white foreground color based on background luminance
+# Usage: get_contrast_fg "#fab387"
+# Returns: hex color ("#000000" for light bg, "#ffffff" for dark bg)
+get_contrast_fg() {
+    local variant
+    variant=$(get_contrast_variant "$1")
+    if [[ "$variant" == "darkest" ]]; then
+        printf '#000000'
+    else
+        printf '#ffffff'
+    fi
+}
+
+# =============================================================================
 # Plugin Color Resolution
 # =============================================================================
 
@@ -291,40 +308,3 @@ reset_style() {
     printf '#[default]'
 }
 
-# =============================================================================
-# Color Utilities
-# =============================================================================
-
-# Get contrasting text color for a background
-# Usage: get_contrast_color "#1a1b26"
-# Returns appropriate fg color based on background luminance
-get_contrast_color() {
-    local bg="$1"
-
-    # Remove # if present
-    bg="${bg#\#}"
-
-    # Default to light text (statusbar-fg is light for dark themes)
-    local light_text dark_text
-    light_text=$(resolve_color "statusbar-fg")
-    dark_text=$(resolve_color "session-fg")
-
-    # If not a valid hex, return default light text
-    [[ ! "$bg" =~ ^[0-9a-fA-F]{6}$ ]] && { printf '%s' "$light_text"; return; }
-
-    # Calculate luminance (simplified)
-    local r=$((16#${bg:0:2}))
-    local g=$((16#${bg:2:2}))
-    local b=$((16#${bg:4:2}))
-
-    # Perceived luminance formula
-    local luminance=$(( (r * 299 + g * 587 + b * 114) / 1000 ))
-
-    if (( luminance > 128 )); then
-        # Light background - use dark text
-        printf '%s' "$dark_text"
-    else
-        # Dark background - use light text
-        printf '%s' "$light_text"
-    fi
-}

--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -60,8 +60,11 @@ _windows_get_colors() {
 
     if [[ "$state" == "active" ]]; then
         base_color="window-active-base"
-        index_fg=$(resolve_color "${base_color}-lightest")
-        content_fg=$(resolve_color "${base_color}-lightest")
+        # Choose text color based on background luminance for readability
+        local fg_variant
+        fg_variant=$(get_contrast_variant "$base_color")
+        index_fg=$(resolve_color "${base_color}-${fg_variant}")
+        content_fg=$(resolve_color "${base_color}-${fg_variant}")
     else
         base_color="window-inactive-base"
         index_fg=$(resolve_color "white")

--- a/src/renderer/segment_builder.sh
+++ b/src/renderer/segment_builder.sh
@@ -635,8 +635,26 @@ _resolve_plugin_colors() {
         local content_bg content_fg icon_bg icon_fg
         content_bg=$(resolve_color "${accent:-ok-base}")
         icon_bg=$(resolve_color "${accent_icon:-${accent:-ok-base}-lighter}")
-        content_fg=$(resolve_color "${accent:-ok-base}-darkest")
-        icon_fg=$(resolve_color "${accent_icon:-${accent:-ok-base}}-darkest")
+
+        if [[ "${accent}" == \#* ]]; then
+            # Raw hex accent: use black/white for guaranteed contrast
+            content_fg=$(get_contrast_fg "$content_bg")
+        else
+            # Theme color name: use matching variant for harmony
+            local fg_variant
+            fg_variant=$(get_contrast_variant "$content_bg")
+            content_fg=$(resolve_color "${accent}-${fg_variant}")
+        fi
+
+        local effective_icon_accent="${accent_icon:-${accent:-ok-base}}"
+        if [[ "${effective_icon_accent}" == \#* ]]; then
+            icon_fg=$(get_contrast_fg "$icon_bg")
+        else
+            local icon_fg_variant
+            icon_fg_variant=$(get_contrast_variant "$icon_bg")
+            icon_fg=$(resolve_color "${effective_icon_accent}-${icon_fg_variant}")
+        fi
+
         printf '%s %s %s %s' "$content_bg" "$content_fg" "$icon_bg" "$icon_fg"
     else
         # Regular plugin: resolve via state/health


### PR DESCRIPTION
## Problem

Text on status bar segments is frequently unreadable depending on the theme, because foreground colors are hardcoded without considering the actual background brightness.

Three specific areas are broken:

1. **Active window tabs** always use the `-lightest` variant for text. On themes with light `window-active-base` colors (Catppuccin's pink `#f5c2e7`, blue `#89b4fa`, etc.), this produces near-white text on a pastel background.

2. **Plugin segments** hardcode white text for `ok` health and `-darkest` for everything else. This assumes ok backgrounds are always dark and other health colors are always light — which doesn't hold across themes.

3. **External plugin segments** append `-darkest` to the raw accent color name to derive text color. When the accent is a hex value like `#fab387`, this tries to resolve `#fab387-darkest`, which isn't a valid color name. It silently falls back to an unreadable default.

## Fix

Add a perceived luminance check (ITU-R BT.601) that dynamically picks dark or light text based on the actual resolved background color.

Two new functions:

- **`get_contrast_variant(color)`** in `color_palette.sh` (core layer) — accepts a theme color name or hex, computes luminance, returns `"darkest"` or `"lightest"`. Used by windows and regular plugins that work within the named variant system.

- **`get_contrast_fg(hex)`** in `color_resolver.sh` (renderer layer) — returns `#000000` or `#ffffff`. Used only when the variant system doesn't apply (raw hex accent colors from external plugins).

Luminance formula: `(299*R + 587*G + 114*B) / 1000`, threshold at 128.

### Changes by file

**`src/core/color_palette.sh`**
- Add `get_contrast_variant()` with hex validation (gracefully handles non-hex inputs instead of crashing)
- Replace the `case "$health"` block in `get_plugin_colors()` with luminance-based fg selection for both content and icon text

**`src/renderer/color_resolver.sh`**
- Add `get_contrast_fg()` for raw hex → black/white resolution
- Remove unused `get_contrast_color()` which duplicated the same luminance logic

**`src/renderer/entities/windows.sh`**
- Replace hardcoded `-lightest` for active window text with `get_contrast_variant()` call

**`src/renderer/segment_builder.sh`**
- External plugins now branch on accent type: theme color names use the variant system (`accent-darkest` / `accent-lightest`) for visual harmony with the theme, raw hex accents use pure black/white for guaranteed contrast

## Testing

Test with themes that have both light and dark base colors:
- Light `window-active-base`: Catppuccin Mocha (pink `#f5c2e7`, blue `#89b4fa`) — should get dark text
- Dark `window-inactive-base`: Catppuccin Mocha (surface1 `#45475a`) — should get light text
- Light plugin colors: `warning-base` (yellow `#f9e2af`), `good-base` (green `#a6e3a1`) — should get dark text
- Dark plugin colors: `ok-base` on dark themes — should get light text
- External plugins with hex accents: both light (`#fab387`) and dark (`#2e3440`) values
- External plugins with theme color accents: `warning-base`, `info-base`, etc.