### PR TITLE
fix(plugins): count iowait as idle time

### DIFF
--- a/src/plugins/cpu.sh
+++ b/src/plugins/cpu.sh
@@ -92,7 +92,7 @@ _get_cpu_linux() {
     line=$(grep '^cpu ' /proc/stat 2>/dev/null)
     [[ -z "$line" ]] && { echo "0"; return; }
     read -ra vals <<< "${line#cpu }"
-    idle1=${vals[3]}
+    idle1=$((vals[3] + vals[4]))
     total1=0
     for v in "${vals[@]}"; do
         total1=$((total1 + v))
@@ -104,7 +104,7 @@ _get_cpu_linux() {
     # Second sample
     line=$(grep '^cpu ' /proc/stat 2>/dev/null)
     read -ra vals <<< "${line#cpu }"
-    idle2=${vals[3]}
+    idle2=$((vals[3] + vals[4]))
     total2=0
     for v in "${vals[@]}"; do
         total2=$((total2 + v))


### PR DESCRIPTION
Include iowait in idle time to align with [htop CPU usage calculations](https://github.com/htop-dev/htop/blob/348c0a6bf4f33571835a0b6a1a0f5deb15132128/linux/LinuxMachine.c#L449).

