### PR TITLE
fix(windows): use luminance-based contrast for window tab text

### DIFF
--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -60,13 +60,14 @@ _windows_get_colors() {
 
     if [[ "$state" == "active" ]]; then
         base_color="window-active-base"
-        index_fg=$(resolve_color "${base_color}-lightest")
-        content_fg=$(resolve_color "${base_color}-lightest")
     else
         base_color="window-inactive-base"
-        index_fg=$(resolve_color "white")
-        content_fg=$(resolve_color "white")
     fi
+
+    local variant
+    variant=$(get_contrast_variant "$base_color")
+    index_fg=$(resolve_color "${base_color}-${variant}")
+    content_fg=$(resolve_color "${base_color}-${variant}")
 
     index_bg=$(resolve_color "${base_color}-light")
     content_bg=$(resolve_color "$base_color")


### PR DESCRIPTION
My [previous fix](https://github.com/fabioluciano/tmux-powerkit/pull/181) added the luminance logic but didn't actually use it 🤦‍♂️

## Summary
- Replace hardcoded `-lightest` and `"white"` text colors in `_windows_get_colors()` with `get_contrast_variant()` to dynamically choose between `-darkest` and `-lightest` based on background luminance
- Fixes unreadable text on themes with light/pastel window background colors (e.g., Catppuccin Mocha's pink `#f5c2e7`)
- Consistent with how `segment_builder.sh` already handles plugin text colors using luminance checks

## Test plan
- [ ] Verify window tab text is readable with dark-background themes (e.g., Tokyo Night)
- [ ] Verify window tab text is readable with light/pastel-background themes (e.g., Catppuccin Mocha)
- [ ] Verify both active and inactive window tabs have proper contrast