### PR TITLE
fix(weather): return success when static icon mode skips dynamic symbol

### DIFF
--- a/src/plugins/weather.sh
+++ b/src/plugins/weather.sh
@@ -920,6 +920,7 @@ plugin_collect() {
     # Step 7: Store data
     plugin_data_set "weather" "$weather_text"
     [[ -n "$symbol" ]] && plugin_data_set "symbol" "$symbol"
+    return 0
 }
 
 # =============================================================================
@@ -931,4 +932,3 @@ plugin_render() {
     weather=$(plugin_data_get "weather")
     [[ -n "$weather" ]] && printf '%s' "$weather"
 }
-


### PR DESCRIPTION
Fixes the weather plugin when `@powerkit_plugin_weather_icon_mode` is set to static.

`plugin_collect()` could return failure just because no dynamic weather symbol was set, even when weather text was fetched successfully. 

This change adds an explicit success return so static icon mode renders correctly without affecting dynamic mode.