### PR TITLE
fix(battery): align warning icon option with plugin contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Every plugin is highly customizable. Example with the `battery` plugin:
 set -g @powerkit_plugin_battery_warning_threshold "30"
 set -g @powerkit_plugin_battery_critical_threshold "15"
 set -g @powerkit_plugin_battery_icon ""
+set -g @powerkit_plugin_battery_icon_warning "󰂃"
 set -g @powerkit_plugin_battery_icon_charging "󰂄"
 set -g @powerkit_plugin_battery_cache_ttl "5"
 set -g @powerkit_plugin_battery_show_only_on_threshold "false"

--- a/src/plugins/battery.sh
+++ b/src/plugins/battery.sh
@@ -77,7 +77,7 @@ plugin_declare_options() {
     # Icons
     declare_option "icon" "icon" $'\U000F0079' "Default battery icon (full)"
     declare_option "icon_charging" "icon" $'\U000F0084' "Charging/AC power icon"
-    declare_option "icon_low" "icon" $'\U000F0083' "Low battery icon"
+    declare_option "icon_warning" "icon" $'\U000F0083' "Warning battery icon"
     declare_option "icon_critical" "icon" $'\U000F008E' "Critical battery icon"
 
     # Cache
@@ -376,7 +376,7 @@ plugin_get_icon() {
             ;;
     esac
 
-    # Use health-based icon selection (icon_critical -> icon_low -> icon)
+    # Use health-based icon selection (icon_critical -> icon_warning -> icon)
     plugin_get_icon_by_health "$(plugin_get_health)"
 }
 


### PR DESCRIPTION
Fix battery warning icon config to match the shared plugin contract.

The battery plugin declared `icon_low`, but health-based icon rendering reads `icon_warning`. Because of that mismatch, warning-state battery icon overrides were ignored.

This PR renames the option to `icon_warning` as it's already the contract name.