### PR TITLE
fix(renderer): window index padding and spacing without separators

### DIFF
--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -190,6 +190,19 @@ _windows_get_spacing_sep_char() {
     fi
 }
 
+# Build window index text with padding appropriate to separator style.
+# Glyph separators provide a visual right edge, but separator_style=none needs
+# an explicit trailing cell before the index-to-content transition.
+_windows_build_index_text() {
+    local side="$1" index_fg="$2" index_bg="$3" style_attr="$4"
+
+    if [[ "$side" == "left" && -n "$_W_SEP_CHAR" ]]; then
+        printf '#[fg=%s,bg=%s%s] %s' "$index_fg" "$index_bg" "$style_attr" "$(window_get_index_display)"
+    else
+        printf '#[fg=%s,bg=%s%s]%s ' "$index_fg" "$index_bg" "$style_attr" "$(window_get_index_display)"
+    fi
+}
+
 # Build spacing separator (if enabled)
 # Usage: _windows_build_spacing "side" "content_bg"
 # Note: "center" behaves like "left" for separator direction
@@ -274,7 +287,7 @@ _windows_build_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
+        format+=$(_windows_build_index_text "$side" "$index_fg" "$index_bg" "$style_attr")
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
     # Add left padding only when rendering from left side
@@ -335,7 +348,7 @@ _windows_build_current_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
+        format+=$(_windows_build_index_text "$side" "$index_fg" "$index_bg" "$style_attr")
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
     # Add left padding only when rendering from left side

--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -274,12 +274,7 @@ _windows_build_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        # Add left padding only when rendering from left side
-        if [[ "$side" == "left" ]]; then
-            format+="#[fg=${index_fg},bg=${index_bg}${style_attr}] $(window_get_index_display)"
-        else
-            format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
-        fi
+        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
     # Add left padding only when rendering from left side
@@ -340,12 +335,7 @@ _windows_build_current_format() {
     format+=$(_windows_build_separator "$side" "$first_segment_bg" "$previous_bg")
     # Show index section only if enabled
     if [[ "$show_index" == "true" ]]; then
-        # Add left padding only when rendering from left side
-        if [[ "$side" == "left" ]]; then
-            format+="#[fg=${index_fg},bg=${index_bg}${style_attr}] $(window_get_index_display)"
-        else
-            format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
-        fi
+        format+="#[fg=${index_fg},bg=${index_bg}${style_attr}]$(window_get_index_display) "
         format+=$(_windows_build_index_sep "$side" "$index_bg" "$content_bg")
     fi
     # Add left padding only when rendering from left side

--- a/src/renderer/segment_builder.sh
+++ b/src/renderer/segment_builder.sh
@@ -525,10 +525,11 @@ _build_spacing_separator() {
 
     # Spacing separator: fg=theme_background, bg=plugin_color
     # Triangle filled with theme background color (looks transparent)
-    if [[ "$side" == "left" ]]; then
-        printf ' #[fg=%s,bg=%s]%s#[none]' "$spacing_fg" "$prev_bg" "$spacing_sep"
+    if [[ -z "$spacing_sep" ]]; then
+        printf '#[fg=%s,bg=%s] #[none]#[fg=%s,bg=%s] #[none]' \
+            "$spacing_fg" "$prev_bg" "$spacing_fg" "$spacing_fg"
     else
-        printf ' #[fg=%s,bg=%s]%s#[none]' "$spacing_fg" "$prev_bg" "$spacing_sep"
+        printf '#[fg=%s,bg=%s]%s#[none]' "$spacing_fg" "$prev_bg" "$spacing_sep"
     fi
 }
 
@@ -782,10 +783,11 @@ render_plugins() {
 
             # Spacing separator: fg=statusbar_bg, bg=plugin_color
             # Triangle filled with statusbar background color on plugin background
-            if [[ "$side" == "left" ]]; then
-                output+=" #[fg=${current_spacing_fg},bg=${prev_bg}]${spacing_sep}#[none]"
+            if [[ -z "$spacing_sep" ]]; then
+                output+="#[fg=${current_spacing_fg},bg=${prev_bg}] #[none]"
+                output+="#[fg=${current_spacing_fg},bg=${current_spacing_bg}] #[none]"
             else
-                output+=" #[fg=${current_spacing_fg},bg=${prev_bg}]${spacing_sep}#[none]"
+                output+="#[fg=${current_spacing_fg},bg=${prev_bg}]${spacing_sep}#[none]"
             fi
             prev_bg="${current_spacing_bg}"
         # For same group without global spacing, still need to update prev_bg context


### PR DESCRIPTION
## Summary

- Adjust window index padding for `separator_style=none` while preserving existing padding for glyph-based separators.
- Keep plugin spacing visually consistent with window spacing when separators are disabled.
- Preserve existing behavior for powerline-style and other glyph separators