### PR TITLE
docs: Added missing icon configuration option for git plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ set -g @powerkit_plugin_cpu_icon ""
 ### Git Plugin
 
 ```bash
-set -g @powerkit_plugin_git_icon ""
+set -g @powerkit_plugin_git_icon "" # Default git icon
+set -g @powerkit_plugin_git_icon_modified "" # Icon used when repository has modifications
 set -g @powerkit_plugin_git_show_branch "true"
 set -g @powerkit_plugin_git_show_files "true"
 set -g @powerkit_plugin_git_max_length "30"


### PR DESCRIPTION
When I was trying to change the git icon I noticed no matter how many times I reloaded tmux and creared the cache from powerkit it wouldn't change which is when I realized there was another setting to set the git icon hidden deep in the source code. Hopefully this helps others.