### PR TITLE
fix: improve security and reliability across core and plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ PowerKit is a contract-based tmux status bar framework with strict separation of
 - **Renderer**: ALL UI decisions (colors, icons, formatting)
 - **Theme**: Color definitions ONLY
 
-**Target**: Bash 4+ | **Architecture**: Contract-based plugin system
+**Target**: Bash 5.0+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`) | **Architecture**: Contract-based plugin system
 
 ## Directory Structure
 
@@ -687,7 +687,7 @@ Native binaries are compiled from Swift source in `src/native/macos/`. Users can
 rm -f ~/.cache/tmux-powerkit/data/binary_decision_*
 
 # Clear tracking files
-rm -f /tmp/powerkit_missing_binaries /tmp/powerkit_binary_pending_all
+rm -f ~/.cache/tmux-powerkit/runtime/missing_binaries ~/.cache/tmux-powerkit/runtime/binary_pending_all
 
 # Remove binaries to force re-download
 rm -f ~/.config/tmux/plugins/tmux-powerkit/bin/powerkit-{gpu,temperature,microphone,nowplaying,brightness}

--- a/src/contract/message_contract.sh
+++ b/src/contract/message_contract.sh
@@ -145,7 +145,9 @@ message_popup_cmd() {
     local height="${4:-24}"
 
     if [[ -z "${TMUX:-}" ]]; then
-        eval "$cmd"
+        # Run in a child shell (same as the popup path) instead of eval,
+        # so the command cannot mutate the caller's shell state
+        bash -c "$cmd"
         return
     fi
 

--- a/src/core/binary_manager.sh
+++ b/src/core/binary_manager.sh
@@ -24,8 +24,19 @@ _BINARY_DIR="${POWERKIT_ROOT}/bin"
 declare -ga _MISSING_BINARIES=()
 declare -gA _MISSING_BINARY_PLUGINS=()
 
+# User-private runtime dir for transient state. Using a fixed path under
+# world-writable /tmp would allow other local users to pre-create/symlink
+# these files (TOCTOU), including the popup script we execute.
+_BINARY_RUNTIME_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-powerkit/runtime"
+
 # File to persist missing binaries across subshells (stable name)
-_MISSING_BINARIES_FILE="/tmp/powerkit_missing_binaries"
+_MISSING_BINARIES_FILE="${_BINARY_RUNTIME_DIR}/missing_binaries"
+
+# Ensure the runtime dir exists and is private to the user
+_binary_runtime_init() {
+    [[ -d "$_BINARY_RUNTIME_DIR" ]] && return 0
+    mkdir -p "$_BINARY_RUNTIME_DIR" 2>/dev/null && chmod 700 "$_BINARY_RUNTIME_DIR"
+}
 
 # =============================================================================
 # Internal Functions
@@ -123,6 +134,7 @@ _track_missing_binary() {
     if [[ -f "$_MISSING_BINARIES_FILE" ]] && grep -q "^${binary}:" "$_MISSING_BINARIES_FILE" 2>/dev/null; then
         return 0
     fi
+    _binary_runtime_init
     echo "${binary}:${plugin}" >> "$_MISSING_BINARIES_FILE"
 
     log_debug "binary_manager" "Tracked missing binary: $binary for plugin $plugin"
@@ -144,7 +156,7 @@ binary_has_missing() {
 # Usage: binary_prompt_missing
 # Called after all plugins are initialized
 binary_prompt_missing() {
-    local pending_file="/tmp/powerkit_binary_pending_all"
+    local pending_file="${_BINARY_RUNTIME_DIR}/binary_pending_all"
 
     # Check if popup is already pending
     if [[ -f "$pending_file" ]]; then
@@ -169,12 +181,13 @@ binary_prompt_missing() {
     [[ $count -eq 0 ]] && return 0
 
     # Mark as pending
+    _binary_runtime_init
     echo "1" > "$pending_file"
 
     log_info "binary_manager" "Prompting for ${count} missing binaries"
 
     # Write command to temp file for execution
-    local cmd_file="/tmp/powerkit_popup_cmd"
+    local cmd_file="${_BINARY_RUNTIME_DIR}/popup_cmd"
     cat > "$cmd_file" << EOF
 #!/usr/bin/env bash
 tmux display-popup -E -w 60% -h 70% -T ' PowerKit - Binary Download ' \
@@ -198,7 +211,10 @@ binary_download() {
 
     url=$(binary_get_download_url "$binary")
     arch_suffix=$(binary_get_arch_suffix)
-    temp_file="/tmp/${binary}-${arch_suffix}-$$"
+    temp_file=$(mktemp "${TMPDIR:-/tmp}/powerkit-binary.XXXXXX") || {
+        log_error "binary_manager" "Failed to create temp file for ${binary}"
+        return 1
+    }
 
     log_info "binary_manager" "Downloading ${binary} from ${url}"
 
@@ -214,6 +230,21 @@ binary_download() {
         log_error "binary_manager" "Downloaded file is not a valid macOS binary"
         rm -f "$temp_file" 2>/dev/null
         return 1
+    fi
+
+    # Verify integrity when a .sha256 asset is published for the release
+    local expected_sha actual_sha
+    expected_sha=$(curl -fsSL --connect-timeout 5 --max-time 10 "${url}.sha256" 2>/dev/null | awk '{print $1}')
+    if [[ "$expected_sha" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        actual_sha=$(shasum -a 256 "$temp_file" 2>/dev/null | awk '{print $1}')
+        if [[ "$actual_sha" != "$expected_sha" ]]; then
+            log_error "binary_manager" "Checksum mismatch for ${binary} (expected ${expected_sha}, got ${actual_sha:-none})"
+            rm -f "$temp_file" 2>/dev/null
+            return 1
+        fi
+        log_debug "binary_manager" "Checksum verified for ${binary}"
+    else
+        log_warn "binary_manager" "No checksum published for ${binary}; skipping verification"
     fi
 
     # Make executable and move to bin dir

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -443,10 +443,9 @@ _resolve_external_plugin() {
 
     # Execute content command
     local output=""
-    if [[ "$content" == "\$(("* || "$content" == "#("* ]]; then
+    if [[ "$content" == "\$("* || "$content" == "#("* ]]; then
         # Command to execute
         local cmd="${content#\$(}"
-        cmd="${cmd%\)}"
         cmd="${cmd#\#(}"
         cmd="${cmd%\)}"
         output=$(eval "$cmd" 2>/dev/null || true)
@@ -862,8 +861,15 @@ collect_external_plugin_render_data() {
 
     # Execute content command if it looks like a command
     local output=""
-    if [[ "$content" == *'$('* || "$content" == *'#('* ]]; then
-        # Command substitution - execute it
+    if [[ ("$content" == "\$("* || "$content" == "#("*) && "$content" == *")" ]]; then
+        # Pure command: strip the wrapper and execute directly.
+        # Avoids re-quoting the command, so embedded quotes work as written.
+        local cmd="${content#\$(}"
+        cmd="${cmd#\#(}"
+        cmd="${cmd%\)}"
+        output=$(eval "$cmd" 2>/dev/null || printf '%s' "$content")
+    elif [[ "$content" == *'$('* || "$content" == *'#('* ]]; then
+        # Command substitution embedded in text - expand it
         local cmd="${content}"
         # Convert #(...) to $(...) for eval
         cmd="${cmd//#\(/\$(}"

--- a/src/plugins/datetime.sh
+++ b/src/plugins/datetime.sh
@@ -47,7 +47,9 @@ plugin_get_state() { printf 'active'; }
 plugin_get_health() { printf 'ok'; }
 
 plugin_get_context() {
-    local hour=$(date +%H)
+    local hour
+    printf -v hour '%(%H)T' -1
+    hour=$((10#$hour))  # Force base 10: "08"/"09" would be invalid octal
     if (( hour >= 6 && hour < 12 )); then
         printf 'morning'
     elif (( hour >= 12 && hour < 18 )); then
@@ -85,7 +87,7 @@ declare -A FORMATS=(
 )
 
 _resolve_format() {
-    local f="${1:-}"
+    local f="${1:-datetime}"
     printf '%s' "${FORMATS[$f]:-$f}"
 }
 
@@ -109,17 +111,27 @@ plugin_render() {
     show_week=$(plugin_data_get "show_week")
     separator=$(plugin_data_get "separator")
 
-    local out="" sep="${separator:- }"
+    local out="" part="" sep="${separator:- }"
     local fmt=$(_resolve_format "$format")
 
+    # Uses the printf '%(...)T' builtin (strftime) instead of the external
+    # date command: render must not execute external commands
+
     # Week number
-    [[ "$show_week" == "true" ]] && out="$(date +W%V 2>/dev/null || date +W%W)${sep}"
+    if [[ "$show_week" == "true" ]]; then
+        printf -v part '%(W%V)T' -1
+        out="${part}${sep}"
+    fi
 
     # Main datetime
-    out+=$(date +"$fmt" 2>/dev/null)
+    printf -v part "%(${fmt})T" -1
+    out+="$part"
 
     # Secondary timezone
-    [[ -n "$timezone" ]] && out+="${sep}$(TZ="$timezone" date +%H:%M 2>/dev/null)"
+    if [[ -n "$timezone" ]]; then
+        TZ="$timezone" printf -v part '%(%H:%M)T' -1
+        out+="${sep}${part}"
+    fi
 
     printf '%s' "$out"
 }

--- a/src/plugins/uptime.sh
+++ b/src/plugins/uptime.sh
@@ -42,18 +42,20 @@ plugin_get_context() {
 
 plugin_collect() {
     local uptime_seconds=0
-        if is_linux && [[ -r /proc/uptime ]]; then
-            uptime_seconds=$(awk '{printf "%d", $1}' /proc/uptime 2>/dev/null)
-        elif is_macos; then
-            # macOS: use sysctl to get boot time (campo 'sec')
-            local boot_time now=$EPOCHSECONDS
-            boot_time=$(sysctl -n kern.boottime | awk '{gsub(",", "", $4); print $4}')
-            ((uptime_seconds=now-boot_time))
+    if is_linux && [[ -r /proc/uptime ]]; then
+        uptime_seconds=$(awk '{printf "%d", $1}' /proc/uptime 2>/dev/null)
+    elif is_macos; then
+        # macOS: use sysctl to get boot time ('sec' field)
+        local boot_time now=$EPOCHSECONDS
+        boot_time=$(sysctl -n kern.boottime 2>/dev/null | awk '{gsub(",", "", $4); print $4}')
+        if [[ "$boot_time" =~ ^[0-9]+$ ]]; then
+            ((uptime_seconds = now - boot_time))
+        fi
     else
         # Fallback: parse uptime output
         uptime_seconds=$(uptime | awk -F'( |,|:)+' '{if ($7=="min") print $6*60; else if ($7=="hrs") print $6*3600; else print 0}')
     fi
-    plugin_data_set "uptime" "$(format_uptime_seconds "$uptime_seconds")"
+    plugin_data_set "uptime" "$(format_uptime_seconds "${uptime_seconds:-0}")"
 }
 
 plugin_render() {


### PR DESCRIPTION
## Summary

This PR addresses multiple security vulnerabilities and reliability issues across the codebase:

1. **Security**: Moves temporary files from world-writable `/tmp` to user-private `~/.cache/tmux-powerkit/runtime` directory to prevent TOCTOU attacks and privilege escalation
2. **Reliability**: Replaces external `date` command calls with bash builtin `printf '%(...)T'` to eliminate subprocess overhead and improve robustness
3. **Integrity**: Adds SHA256 checksum verification for downloaded binaries
4. **Robustness**: Improves error handling and input validation across multiple plugins

## Key Changes

### Binary Manager Security (`src/core/binary_manager.sh`)
- Move temporary files from `/tmp/powerkit_*` to `${XDG_CACHE_HOME:-$HOME/.cache}/tmux-powerkit/runtime/`
- Add `_binary_runtime_init()` function to create runtime directory with `700` permissions (user-private)
- Implement SHA256 checksum verification for downloaded binaries with fallback warning
- Use `mktemp` for secure temporary file creation instead of predictable naming

### DateTime Plugin Reliability (`src/plugins/datetime.sh`)
- Replace all `date` command calls with bash builtin `printf '%(...)T'` for better performance
- Fix octal number parsing issue: force base-10 interpretation of hour values ("08"/"09" are invalid octal)
- Fix format resolution to default to "datetime" instead of empty string
- Improve timezone handling with proper variable initialization

### Uptime Plugin Robustness (`src/plugins/uptime.sh`)
- Add validation for boot_time parsing on macOS (check for numeric format)
- Fix indentation consistency
- Add fallback handling for missing uptime data with `${uptime_seconds:-0}`
- Improve error handling in sysctl calls

### Lifecycle Command Execution (`src/core/lifecycle.sh`)
- Fix regex pattern for detecting command substitution (was matching `\$((`  instead of `\$(`)
- Improve command extraction logic to handle both `$(...)` and `#(...)` syntax correctly
- Separate pure command execution from embedded command substitution for better reliability
- Use `bash -c` instead of `eval` in message contract to prevent shell state mutation

### Documentation (`CLAUDE.md`)
- Update target Bash version requirement to 5.0+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`)
- Update cache cleanup instructions to reflect new runtime directory location

## Implementation Details

- Runtime directory uses `XDG_CACHE_HOME` standard with fallback to `~/.cache`
- Directory permissions set to `700` (rwx------) to prevent other users from accessing
- Checksum verification is optional (warns if not available, doesn't fail)
- All external command calls in render path replaced with builtins to meet contract requirements
- Error handling improved with proper validation and fallback values