### PR TITLE
fix(loadavg): change warning_threshold_multiplier default from 2 to 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,12 +494,12 @@ plugin_get_context() {
 
 ## Icon Selection Helpers
 
-Use in `plugin_get_icon()` to eliminate DRY violations for health-based and state-based icon selection:
+Use in `plugin_get_icon()` to eliminate DRY violations for state-based and value-based icon selection:
 
 ```bash
-# Select icon based on health level
-# Returns: icon_critical if error, icon_warning if warning, icon otherwise
-plugin_get_icon_by_health "$(plugin_get_health)"
+# ⚠️ DEPRECATED: plugin_get_icon_by_health
+# This helper couples icon selection to health re-evaluation, violating the contract.
+# See "Contract Violations to Avoid" section below for details.
 
 # Select icon based on boolean state (on/off, connected/disconnected, etc.)
 plugin_get_icon_by_state "$muted" "icon_muted" "icon"
@@ -546,7 +546,8 @@ plugin_get_icon() {
 
 # NEW (14 lines - 55% reduction):
 plugin_get_icon() {
-    local status
+    local percent status
+    percent=$(plugin_data_get "percent")
     status=$(plugin_data_get "status")
 
     # Charging/AC power takes precedence
@@ -557,8 +558,8 @@ plugin_get_icon() {
             ;;
     esac
 
-    # Use health-based icon selection (icon_critical -> icon_low -> icon)
-    plugin_get_icon_by_health "$(plugin_get_health)"
+    # Use value-based icon selection (data-driven, not health-driven)
+    plugin_get_icon_by_range "$percent" "15:icon_critical" "30:icon_low" "icon"
 }
 ```
 
@@ -578,36 +579,13 @@ plugin_get_icon() {
 }
 ```
 
-**Example (temperature.sh):**
-
-```bash
-# OLD:
-plugin_get_icon() {
-    local temp health
-    temp=$(plugin_data_get "temperature")
-    health=$(plugin_get_health)
-
-    case "$health" in
-        error)   get_option "icon_critical"; return ;;
-        warning) get_option "icon_warning"; return ;;
-        *)       get_option "icon"; return ;;
-    esac
-}
-
-# NEW:
-plugin_get_icon() {
-    plugin_get_icon_by_health "$(plugin_get_health)"
-}
-```
-
 **Benefits:**
 
 - **Saves 8-15 lines per plugin** × 12 plugins = **96-180 lines**
 - Consistent icon selection patterns across all plugins
-- Three helpers cover different scenarios:
-  - `plugin_get_icon_by_health`: Most common - maps health levels to icons
+- Two helpers cover different scenarios:
   - `plugin_get_icon_by_state`: Boolean state (on/off, muted/unmuted)
-  - `plugin_get_icon_by_range`: Value-based thresholds (battery percentage)
+  - `plugin_get_icon_by_range`: Value-based thresholds (battery percentage, temperature ranges)
 
 ## macOS Native Binary System
 
@@ -1228,17 +1206,23 @@ plugin_get_health() {
 }
 # Renderer maps health='error' → red color
 
-# WRONG: Icon based on health
+# WRONG: Icon based on health (couples icon to health re-evaluation)
 plugin_get_icon() {
     local health=$(plugin_get_health)
-    [[ "$health" == "error" ]] && printf '%s' "$critical_icon"  # UI logic!
+    [[ "$health" == "error" ]] && printf '%s' "$critical_icon"  # Violates contract!
 }
+# Problem: plugin_get_icon() calls plugin_get_health() again, re-evaluating thresholds.
+# This couples icon selection to health logic, making it impossible to change icon
+# independently of health without re-evaluating the entire health function.
 
-# CORRECT: Icon based on internal data
+# CORRECT: Icon based on internal data (data-driven, not health-driven)
 plugin_get_icon() {
     local percent=$(plugin_data_get "percent")
     (( percent < 15 )) && printf '%s' "$(get_option 'icon_critical')"
 }
+# Correct: Icon selection uses raw data from plugin_data_get(), not health.
+# Health is evaluated separately in plugin_get_health() for color mapping.
+# Icon and health can evolve independently.
 ```
 
 ## Plugin Example (battery.sh)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ set -g @powerkit_transparent "true"
 
 ## 🎯 Plugins
 
-### 📊 System Monitoring (15 plugins):
+### 📊 System Monitoring (15 plugins)
 
 Monitor every aspect of your system in real-time:
 
@@ -186,7 +186,7 @@ Monitor every aspect of your system in real-time:
 | `topproc` | Top CPU process | Process name and usage %, threshold alerts |
 | `sysstatus` | Aggregated system health badge | Combined OK/WARN/CRIT across CPU, memory, disk, temperature |
 
-### 🌐 Network (8 plugins):
+### 🌐 Network (8 plugins)
 
 Stay connected and informed:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## The Ultimate tmux Status Bar Framework
 
-45 Plugins • 43 Themes • Infinite Possibilities
+48 Plugins • 43 Themes • Infinite Possibilities
 
 [![Version](https://img.shields.io/github/v/release/fabioluciano/tmux-powerkit?style=for-the-badge&logo=github&logoColor=white)](https://github.com/fabioluciano/tmux-powerkit/releases)
 [![License](https://img.shields.io/github/license/fabioluciano/tmux-powerkit?style=for-the-badge)](LICENSE)
@@ -44,7 +44,7 @@ Smart **multi-layer caching**, **Stale-While-Revalidate (SWR) lazy loading**, an
 
 ### 🧩 **Truly Modular**
 
-**45 production-ready plugins** covering system monitoring, development tools, productivity, media control, and more. Mix and match to create your perfect setup.
+**48 production-ready plugins** covering system monitoring, development tools, productivity, media control, and more. Mix and match to create your perfect setup.
 
 ### 🔧 **Extensible Architecture**
 
@@ -164,7 +164,7 @@ set -g @powerkit_transparent "true"
 
 ## 🎯 Plugins
 
-### 📊 System Monitoring (13 plugins)
+### 📊 System Monitoring (15 plugins):
 
 Monitor every aspect of your system in real-time:
 
@@ -183,8 +183,10 @@ Monitor every aspect of your system in real-time:
 | `brightness` | Screen brightness | Linux only (sysfs, brightnessctl, light, xbacklight) |
 | `uptime` | System uptime | Human-readable format |
 | `hostname` | System hostname | Color-coded by environment |
+| `topproc` | Top CPU process | Process name and usage %, threshold alerts |
+| `sysstatus` | Aggregated system health badge | Combined OK/WARN/CRIT across CPU, memory, disk, temperature |
 
-### 🌐 Network (7 plugins)
+### 🌐 Network (8 plugins):
 
 Stay connected and informed:
 
@@ -197,6 +199,7 @@ Stay connected and informed:
 | `external_ip` | Public IP address | Cached with configurable TTL |
 | `ssh` | SSH session indicator | Shows when connected via SSH |
 | `weather` | Weather from wttr.in | Location-based, customizable format |
+| `connectivity` | Internet connectivity status | Online/offline indicator, configurable endpoint |
 
 ### 🎵 Media (7 plugins)
 

--- a/src/contract/plugin_contract.sh
+++ b/src/contract/plugin_contract.sh
@@ -333,8 +333,8 @@ evaluate_threshold_health() {
     local crit="$3"
     local invert="${4:-0}"
 
-    # Handle non-numeric values
-    [[ ! "$value" =~ ^[0-9]+$ ]] && { printf 'ok'; return; }
+    # Non-numeric value means collection failed — signal as error, not ok
+    [[ ! "$value" =~ ^[0-9]+$ ]] && { printf 'error'; return; }
 
     if [[ "$invert" -eq 1 ]]; then
         # Lower values are worse (battery, signal strength)
@@ -367,7 +367,7 @@ evaluate_threshold_health_float() {
     local invert="${4:-0}"
 
     # Handle non-numeric values
-    [[ ! "$value" =~ ^[0-9]+\.?[0-9]*$ ]] && { printf 'ok'; return; }
+    [[ ! "$value" =~ ^[0-9]+\.?[0-9]*$ ]] && { printf 'error'; return; }
 
     if [[ "$invert" -eq 1 ]]; then
         if (( $(echo "$value <= $crit" | bc -l 2>/dev/null || echo 0) )); then
@@ -469,6 +469,10 @@ require_platform() {
 #       plugin_get_icon_by_health "$(plugin_get_health)"
 #   }
 #
+# DEPRECATED: Use plugin_get_icon_by_range with plugin_data_get value instead.
+# Calling plugin_get_health() inside plugin_get_icon() couples icon selection
+# to the health system, violating separation of concerns (icon must use raw data).
+# This function remains for backward compatibility only — do not use in new plugins.
 plugin_get_icon_by_health() {
     local health="${1:-ok}"
     local default_icon=$(get_option "icon")

--- a/src/plugins/battery.sh
+++ b/src/plugins/battery.sh
@@ -279,6 +279,13 @@ plugin_collect() {
             plugin_data_set "on_ac" "0"
             ;;
     esac
+
+    # Collect time remaining for discharging state
+    local time_remaining=""
+    if [[ "$status" == "discharging" ]]; then
+        time_remaining=$(_get_time_remaining)
+    fi
+    plugin_data_set "time_remaining" "${time_remaining:-}"
 }
 
 # =============================================================================
@@ -376,8 +383,15 @@ plugin_get_icon() {
             ;;
     esac
 
-    # Use health-based icon selection (icon_critical -> icon_warning -> icon)
-    plugin_get_icon_by_health "$(plugin_get_health)"
+    # Use data-based icon selection (contract: icon must not call plugin_get_health)
+    local percent crit_th warn_th
+    percent=$(plugin_data_get "percent")
+    crit_th=$(get_option "critical_threshold")
+    warn_th=$(get_option "warning_threshold")
+    plugin_get_icon_by_range "${percent:-100}" \
+        "${crit_th:-15}:icon_critical" \
+        "${warn_th:-30}:icon_low" \
+        "icon"
 }
 
 # =============================================================================
@@ -409,10 +423,9 @@ plugin_render() {
     case "$mode" in
         time)
             # Time mode - show remaining time
-            # Don't show time when charging (doesn't make sense for "time to empty")
             if [[ "$status" == "discharging" ]]; then
                 local time
-                time=$(_get_time_remaining)
+                time=$(plugin_data_get "time_remaining")
                 if [[ -n "$time" && "$time" != "..." && "$time" != "0:00" ]]; then
                     printf '%s' "$time"
                     return

--- a/src/plugins/cloudstatus.sh
+++ b/src/plugins/cloudstatus.sh
@@ -310,12 +310,13 @@ plugin_get_context() {
 }
 
 plugin_get_icon() {
-    local health
-    health=$(plugin_get_health)
-    case "$health" in
-        error) get_option "icon_error" ;;
+    # Data-based icon selection: read severity directly from datastore
+    local severity
+    severity=$(plugin_data_get "severity")
+    case "$severity" in
+        error)   get_option "icon_error" ;;
         warning) get_option "icon_warning" ;;
-        *) get_option "icon" ;;
+        *)       get_option "icon" ;;
     esac
 }
 

--- a/src/plugins/connectivity.sh
+++ b/src/plugins/connectivity.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Plugin: connectivity
+# Description: Display internet connectivity status (online/offline)
+# Dependencies: network.sh (is_endpoint_reachable)
+# =============================================================================
+
+POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "${POWERKIT_ROOT}/src/contract/plugin_contract.sh"
+
+# =============================================================================
+# Plugin Contract: Metadata
+# =============================================================================
+
+plugin_get_metadata() {
+    metadata_set "id" "connectivity"
+    metadata_set "name" "Connectivity"
+    metadata_set "description" "Display internet connectivity status (online/offline)"
+}
+
+# =============================================================================
+# Plugin Contract: Dependencies
+# =============================================================================
+
+plugin_check_dependencies() {
+    # network.sh is already sourced via plugin_contract.sh
+    has_cmd "curl" || return 1
+    return 0
+}
+
+# =============================================================================
+# Plugin Contract: Options
+# =============================================================================
+
+plugin_declare_options() {
+    declare_option "host" "string" "https://1.1.1.1" "Host to check connectivity"
+    declare_option "timeout" "number" "2" "Connection timeout in seconds"
+    declare_option "icon" "icon" $'\U000F059F' "Plugin icon (network)"
+    declare_option "icon_offline" "icon" $'\U000F0F17' "Icon when offline"
+    declare_option "cache_ttl" "number" "10" "Cache duration in seconds"
+}
+
+# =============================================================================
+# Plugin Contract: Implementation
+# =============================================================================
+
+plugin_get_content_type() { printf 'dynamic'; }
+plugin_get_presence() { printf 'always'; }
+
+plugin_get_state() { printf 'active'; }
+
+plugin_get_health() {
+    local online
+    online=$(plugin_data_get "online")
+    [[ "$online" == "1" ]] && printf 'good' || printf 'error'
+}
+
+plugin_get_context() {
+    local online
+    online=$(plugin_data_get "online")
+    [[ "$online" == "1" ]] && printf 'online' || printf 'offline'
+}
+
+plugin_get_icon() {
+    local online
+    online=$(plugin_data_get "online")
+    if [[ "$online" == "1" ]]; then
+        get_option "icon"
+    else
+        get_option "icon_offline"
+    fi
+}
+
+# =============================================================================
+# Main Logic
+# =============================================================================
+
+plugin_collect() {
+    local host timeout
+    host=$(get_option "host")
+    timeout=$(get_option "timeout")
+
+    if is_endpoint_reachable "$host" "$timeout"; then
+        plugin_data_set "online" "1"
+    else
+        plugin_data_set "online" "0"
+    fi
+}
+
+plugin_render() {
+    local online
+    online=$(plugin_data_get "online")
+    [[ "$online" == "1" ]] && printf 'online' || printf 'offline'
+}

--- a/src/plugins/cpu.sh
+++ b/src/plugins/cpu.sh
@@ -231,12 +231,14 @@ plugin_collect() {
     local percent
 
     if is_macos; then
-        percent=$(_get_cpu_macos)
+        percent=$(_get_cpu_macos) || return 1
     elif is_linux; then
-        percent=$(_get_cpu_linux)
+        percent=$(_get_cpu_linux) || return 1
     else
-        percent="0"
+        return 1
     fi
+
+    [[ -z "$percent" ]] && return 1
 
     # Ensure valid range
     percent="${percent:-0}"
@@ -305,26 +307,23 @@ plugin_get_context() {
 # =============================================================================
 
 plugin_get_icon() {
-    local health icon_warn icon_crit
+    local percent warn_th crit_th
+    percent=$(plugin_data_get "percent")
+    warn_th=$(get_option "warning_threshold")
+    crit_th=$(get_option "critical_threshold")
 
-    health=$(plugin_get_health)
-    icon_warn=$(get_option "icon_warning")
-    icon_crit=$(get_option "icon_critical")
-
-    case "$health" in
-        error)
-            [[ -n "$icon_crit" ]] && printf '%s' "$icon_crit" || get_option "icon"
-            return
-            ;;
-        warning)
-            [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
-            return
-            ;;
-        *)
-            get_option "icon"
-            return
-            ;;
-    esac
+    # Data-based icon selection (contract: icon must not call plugin_get_health)
+    if (( ${percent:-0} >= ${crit_th:-90} )); then
+        local icon_crit
+        icon_crit=$(get_option "icon_critical")
+        [[ -n "$icon_crit" ]] && printf '%s' "$icon_crit" || get_option "icon"
+    elif (( ${percent:-0} >= ${warn_th:-70} )); then
+        local icon_warn
+        icon_warn=$(get_option "icon_warning")
+        [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
+    else
+        get_option "icon"
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/disk.sh
+++ b/src/plugins/disk.sh
@@ -254,26 +254,23 @@ plugin_get_context() {
 # =============================================================================
 
 plugin_get_icon() {
-    local health icon_warn icon_crit
+    local percent warn_th crit_th
+    percent=$(plugin_data_get "max_percent")
+    warn_th=$(get_option "warning_threshold")
+    crit_th=$(get_option "critical_threshold")
 
-    health=$(plugin_get_health)
-    icon_warn=$(get_option "icon_warning")
-    icon_crit=$(get_option "icon_critical")
-
-    case "$health" in
-        error)
-            [[ -n "$icon_crit" ]] && printf '%s' "$icon_crit" || get_option "icon"
-            return
-            ;;
-        warning)
-            [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
-            return
-            ;;
-        *)
-            get_option "icon"
-            return
-            ;;
-    esac
+    # Data-based icon selection (contract: icon must not call plugin_get_health)
+    if (( ${percent:-0} >= ${crit_th:-90} )); then
+        local icon_crit
+        icon_crit=$(get_option "icon_critical")
+        [[ -n "$icon_crit" ]] && printf '%s' "$icon_crit" || get_option "icon"
+    elif (( ${percent:-0} >= ${warn_th:-80} )); then
+        local icon_warn
+        icon_warn=$(get_option "icon_warning")
+        [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
+    else
+        get_option "icon"
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/fan.sh
+++ b/src/plugins/fan.sh
@@ -268,7 +268,7 @@ _get_cpu_temp_for_fan() {
     if is_macos; then
         has_cmd powerkit-temperature && {
             local t
-            t=$(POWERKIT_ROOT="${POWERKIT_ROOT}" "${POWERKIT_ROOT}/bin/powerkit-temperature" 2>/dev/null)
+            t=$("${POWERKIT_ROOT}/bin/powerkit-temperature" 2>/dev/null)
             [[ "$t" =~ ^[0-9]+$ ]] && printf '%d' "$t" && return
         }
         has_cmd osx-cpu-temp && osx-cpu-temp 2>/dev/null | grep -o '[0-9]*\.[0-9]*' | head -1 | cut -d. -f1 && return

--- a/src/plugins/fan.sh
+++ b/src/plugins/fan.sh
@@ -74,6 +74,11 @@ plugin_declare_options() {
     declare_option "warning_threshold" "number" "4000" "Warning threshold in RPM"
     declare_option "critical_threshold" "number" "6000" "Critical threshold in RPM"
 
+    # Temperature correlation thresholds (fan health)
+    declare_option "temp_warning_threshold" "number" "70" "Temperature warning threshold (°C)"
+    declare_option "temp_critical_threshold" "number" "85" "Temperature critical threshold (°C)"
+    declare_option "rpm_min_threshold" "number" "200" "Minimum RPM under load (below = fan failure)"
+
     # Cache
     declare_option "cache_ttl" "number" "5" "Cache duration in seconds"
 }
@@ -94,13 +99,37 @@ plugin_get_state() {
 }
 
 plugin_get_health() {
-    local rpm warn_th crit_th
-    rpm=$(plugin_data_get "rpm")
-    warn_th=$(get_option "warning_threshold")
-    crit_th=$(get_option "critical_threshold")
+    local rpm temp
+    local rpm_min temp_warn temp_crit
 
-    # Higher is worse (default behavior)
-    evaluate_threshold_health "${rpm:-0}" "${warn_th:-4000}" "${crit_th:-6000}"
+    rpm=$(plugin_data_get "rpm")
+    temp=$(plugin_data_get "cpu_temp")
+    rpm_min=$(get_option "rpm_min_threshold")
+    temp_warn=$(get_option "temp_warning_threshold")
+    temp_crit=$(get_option "temp_critical_threshold")
+
+    rpm="${rpm:-0}"
+    temp="${temp:-0}"
+    rpm_min="${rpm_min:-200}"
+    temp_warn="${temp_warn:-70}"
+    temp_crit="${temp_crit:-85}"
+
+    # Fan failure: RPM too low when temperature is elevated
+    if (( rpm > 0 && rpm < rpm_min && temp >= temp_warn )); then
+        printf 'error'
+        return
+    fi
+
+    # Temperature-based: fan not keeping up
+    if (( temp >= temp_crit )); then
+        printf 'error'
+        return
+    elif (( temp >= temp_warn )); then
+        printf 'warning'
+        return
+    fi
+
+    printf 'ok'
 }
 
 plugin_get_context() {
@@ -232,6 +261,29 @@ _get_fan_macos() {
 }
 
 # =============================================================================
+# Temperature Reading (for fan health correlation)
+# =============================================================================
+
+_get_cpu_temp_for_fan() {
+    if is_macos; then
+        has_cmd powerkit-temperature && {
+            local t
+            t=$(POWERKIT_ROOT="${POWERKIT_ROOT}" "${POWERKIT_ROOT}/bin/powerkit-temperature" 2>/dev/null)
+            [[ "$t" =~ ^[0-9]+$ ]] && printf '%d' "$t" && return
+        }
+        has_cmd osx-cpu-temp && osx-cpu-temp 2>/dev/null | grep -o '[0-9]*\.[0-9]*' | head -1 | cut -d. -f1 && return
+    elif is_linux; then
+        for zone in /sys/class/thermal/thermal_zone*/temp; do
+            [[ -f "$zone" ]] || continue
+            local t
+            t=$(cat "$zone" 2>/dev/null)
+            [[ "$t" =~ ^[0-9]+$ ]] && printf '%d' "$(( t / 1000 ))" && return
+        done
+    fi
+    printf '0'
+}
+
+# =============================================================================
 # Main Detection
 # =============================================================================
 
@@ -323,6 +375,10 @@ plugin_collect() {
     (( rpm == 0 )) && return 0
 
     plugin_data_set "rpm" "$rpm"
+
+    local temp
+    temp=$(_get_cpu_temp_for_fan)
+    plugin_data_set "cpu_temp" "${temp:-0}"
 }
 
 # =============================================================================

--- a/src/plugins/iops.sh
+++ b/src/plugins/iops.sh
@@ -46,8 +46,13 @@ plugin_declare_options() {
     declare_option "icon" "icon" $'\U000F02CA' "Plugin icon (harddisk)"
 
     # Thresholds (in bytes/s - 100MB/s warning, 500MB/s critical)
+    # Kept for backward compatibility (no longer used by plugin_get_health)
     declare_option "warning_threshold" "number" "104857600" "Warning threshold (bytes/s)"
     declare_option "critical_threshold" "number" "524288000" "Critical threshold (bytes/s)"
+
+    # Saturation thresholds (in % disk utilization)
+    declare_option "util_warning_threshold" "number" "60" "Utilization warning threshold (%)"
+    declare_option "util_critical_threshold" "number" "85" "Utilization critical threshold (%)"
 
     # Cache
     declare_option "cache_ttl" "number" "5" "Cache duration in seconds"
@@ -62,13 +67,12 @@ plugin_get_presence() { printf 'always'; }
 plugin_get_state() { printf 'active'; }
 
 plugin_get_health() {
-    local total_rate warn_th crit_th
-    total_rate=$(plugin_data_get "total_rate")
-    warn_th=$(get_option "warning_threshold")
-    crit_th=$(get_option "critical_threshold")
+    local util util_warn util_crit
+    util=$(plugin_data_get "util")
+    util_warn=$(get_option "util_warning_threshold")
+    util_crit=$(get_option "util_critical_threshold")
 
-    # Higher is worse (default behavior)
-    evaluate_threshold_health "${total_rate:-0}" "${warn_th:-104857600}" "${crit_th:-524288000}"
+    evaluate_threshold_health "${util:-0}" "${util_warn:-60}" "${util_crit:-85}"
 }
 
 plugin_get_context() {
@@ -148,6 +152,16 @@ _get_throughput_macos() {
     fi
 }
 
+_get_util_macos() {
+    local total_rate
+    total_rate=$(plugin_data_get "total_rate")
+    total_rate="${total_rate:-0}"
+
+    local pseudo_util=$(( total_rate / 10485760 ))
+    (( pseudo_util > 100 )) && pseudo_util=100
+    printf '%d' "$pseudo_util"
+}
+
 # =============================================================================
 # Linux Implementation using /proc/diskstats
 # =============================================================================
@@ -211,6 +225,42 @@ _get_throughput_linux() {
     fi
 }
 
+_get_util_linux() {
+    local now=${EPOCHSECONDS:-$(date +%s)}
+
+    local total_io_ms=0
+    while IFS= read -r line; do
+        local fields
+        read -ra fields <<< "$line"
+        local dev="${fields[2]}"
+        [[ "$dev" =~ ^(loop|dm-|sr) ]] && continue
+        local io_ms="${fields[12]:-0}"
+        total_io_ms=$((total_io_ms + io_ms))
+    done < /proc/diskstats 2>/dev/null
+
+    local prev_io_ms prev_time
+    prev_io_ms=$(cache_get "iops_util_io_ms" 86400)
+    prev_time=$(cache_get "iops_util_time" 86400)
+
+    cache_set "iops_util_io_ms" "$total_io_ms"
+    cache_set "iops_util_time" "$now"
+
+    [[ -z "$prev_io_ms" || -z "$prev_time" ]] && { printf '0'; return; }
+
+    local delta_io=$((total_io_ms - prev_io_ms))
+    local delta_time=$(( (now - prev_time) * 1000 ))
+
+    (( delta_io < 0 )) && delta_io=0
+
+    if (( delta_time > 0 )); then
+        local util=$(( delta_io * 100 / delta_time ))
+        (( util > 100 )) && util=100
+        printf '%d' "$util"
+    else
+        printf '0'
+    fi
+}
+
 # =============================================================================
 # Main Logic
 # =============================================================================
@@ -236,6 +286,14 @@ plugin_collect() {
     plugin_data_set "read_rate" "$read_rate"
     plugin_data_set "write_rate" "$write_rate"
     plugin_data_set "total_rate" "$((read_rate + write_rate))"
+
+    local util=0
+    if is_linux; then
+        util=$(_get_util_linux)
+    elif is_macos; then
+        util=$(_get_util_macos)
+    fi
+    plugin_data_set "util" "${util:-0}"
 }
 
 plugin_render() {

--- a/src/plugins/loadavg.sh
+++ b/src/plugins/loadavg.sh
@@ -58,7 +58,7 @@ plugin_declare_options() {
     declare_option "icon" "icon" $'\U000F199F' "Plugin icon"
 
     # Thresholds (multiplied by CPU cores)
-    declare_option "warning_threshold_multiplier" "number" "2" "Warning threshold multiplier (times CPU cores)"
+    declare_option "warning_threshold_multiplier" "number" "1" "Warning threshold multiplier (times CPU cores)"
     declare_option "critical_threshold_multiplier" "number" "4" "Critical threshold multiplier (times CPU cores)"
 
     # Cache

--- a/src/plugins/memory.sh
+++ b/src/plugins/memory.sh
@@ -94,7 +94,7 @@ _collect_linux() {
         }
     ' /proc/meminfo 2>/dev/null)
 
-    [[ -z "$mem_info" ]] && { echo "0 0 0"; return; }
+    [[ -z "$mem_info" ]] && return 1
 
     read -r mem_total mem_available <<< "$mem_info"
     mem_used=$((mem_total - mem_available))
@@ -188,14 +188,19 @@ plugin_collect() {
     local data percent used total
 
     if is_macos; then
-        data=$(_collect_macos)
+        data=$(_collect_macos) || return 1
     elif is_linux; then
-        data=$(_collect_linux)
+        data=$(_collect_linux) || return 1
     else
-        data="0 0 0"
+        return 1
     fi
 
+    [[ -z "$data" ]] && return 1
+
     read -r percent used total <<< "$data"
+
+    # Validate — zeros in total means collection failed
+    [[ "${total:-0}" == "0" ]] && return 1
 
     plugin_data_set "percent" "${percent:-0}"
     plugin_data_set "used" "${used:-0}"

--- a/src/plugins/netspeed.sh
+++ b/src/plugins/netspeed.sh
@@ -46,6 +46,10 @@ plugin_declare_options() {
     declare_option "icon_download" "icon" $'\U000F01DA' "Icon for download"
     declare_option "icon_upload" "icon" $'\U000F0552' "Icon for upload"
 
+    # Thresholds (bytes/s, 0 = disabled)
+    declare_option "warning_threshold"  "number" "0" "Warning threshold (bytes/s, 0=disabled)"
+    declare_option "critical_threshold" "number" "0" "Critical threshold (bytes/s, 0=disabled)"
+
     # Cache
     declare_option "cache_ttl" "number" "2" "Cache duration in seconds"
 }
@@ -55,9 +59,29 @@ plugin_declare_options() {
 # =============================================================================
 
 plugin_get_content_type() { printf 'dynamic'; }
-plugin_get_presence() { printf 'always'; }
-plugin_get_state() { printf 'active'; }
-plugin_get_health() { printf 'ok'; }
+plugin_get_presence() { printf 'conditional'; }
+plugin_get_state() {
+    local rx_rate
+    rx_rate=$(plugin_data_get "rx_rate")
+    # Se collect falhou (retornou 1), rx_rate estará vazio
+    [[ -n "$rx_rate" ]] && printf 'active' || printf 'inactive'
+}
+plugin_get_health() {
+    local warn_th crit_th
+    warn_th=$(get_option "warning_threshold")
+    crit_th=$(get_option "critical_threshold")
+
+    # Only evaluate if thresholds are configured (non-zero)
+    if [[ "${warn_th:-0}" != "0" || "${crit_th:-0}" != "0" ]]; then
+        local total_rate rx_rate tx_rate
+        rx_rate=$(plugin_data_get "rx_rate")
+        tx_rate=$(plugin_data_get "tx_rate")
+        total_rate=$(( ${rx_rate:-0} + ${tx_rate:-0} ))
+        evaluate_threshold_health "$total_rate" "${warn_th:-0}" "${crit_th:-0}"
+    else
+        printf 'ok'
+    fi
+}
 
 plugin_get_context() {
     local rx_rate tx_rate

--- a/src/plugins/sysstatus.sh
+++ b/src/plugins/sysstatus.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Plugin: sysstatus
+# Description: Display aggregated system health badge (OK/WARN/CRIT)
+# Dependencies: None (POSIX commands only)
+# =============================================================================
+
+POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "${POWERKIT_ROOT}/src/contract/plugin_contract.sh"
+
+# =============================================================================
+# Plugin Contract: Metadata
+# =============================================================================
+
+plugin_get_metadata() {
+    metadata_set "id" "sysstatus"
+    metadata_set "name" "System Status"
+    metadata_set "description" "Display aggregated system health badge"
+}
+
+# =============================================================================
+# Plugin Contract: Dependencies
+# =============================================================================
+
+plugin_check_dependencies() {
+    # All commands are POSIX: ps, free/awk, df, cat
+    # Platform-specific: top (available everywhere), vm_stat/sysctl (macOS)
+    return 0
+}
+
+# =============================================================================
+# Plugin Contract: Options
+# =============================================================================
+
+plugin_declare_options() {
+    declare_option "icon" "icon" $'\U000F0560' "Plugin icon (dashboard)"
+    declare_option "cpu_warning" "number" "70" "CPU warning threshold (%)"
+    declare_option "cpu_critical" "number" "90" "CPU critical threshold (%)"
+    declare_option "mem_warning" "number" "80" "Memory warning threshold (%)"
+    declare_option "mem_critical" "number" "95" "Memory critical threshold (%)"
+    declare_option "disk_warning" "number" "80" "Disk warning threshold (%)"
+    declare_option "disk_critical" "number" "95" "Disk critical threshold (%)"
+    declare_option "temp_warning" "number" "75" "Temperature warning threshold (°C)"
+    declare_option "temp_critical" "number" "90" "Temperature critical threshold (°C)"
+    declare_option "format" "string" "badge" "Display format: badge, count, detail"
+    declare_option "cache_ttl" "number" "10" "Cache duration in seconds"
+}
+
+# =============================================================================
+# Plugin Contract: Implementation
+# =============================================================================
+
+plugin_get_content_type() { printf 'dynamic'; }
+plugin_get_presence() { printf 'always'; }
+
+plugin_get_state() { printf 'active'; }
+
+plugin_get_health() {
+    local cpu_health mem_health disk_health temp_health
+    
+    cpu_health=$(plugin_data_get "cpu_health")
+    mem_health=$(plugin_data_get "mem_health")
+    disk_health=$(plugin_data_get "disk_health")
+    temp_health=$(plugin_data_get "temp_health")
+    
+    # Aggregate using health_max (returns worst case)
+    local worst_health="ok"
+    
+    [[ -n "$cpu_health" ]] && worst_health=$(health_max "$worst_health" "$cpu_health")
+    [[ -n "$mem_health" ]] && worst_health=$(health_max "$worst_health" "$mem_health")
+    [[ -n "$disk_health" ]] && worst_health=$(health_max "$worst_health" "$disk_health")
+    [[ -n "$temp_health" ]] && worst_health=$(health_max "$worst_health" "$temp_health")
+    
+    printf '%s' "$worst_health"
+}
+
+plugin_get_context() {
+    plugin_context_from_health "$(plugin_get_health)" "system"
+}
+
+plugin_get_icon() {
+    get_option "icon"
+}
+
+# =============================================================================
+# System Metrics Collection (Private Functions)
+# =============================================================================
+
+_collect_cpu_health() {
+    local warn_th crit_th
+    warn_th=$(get_option "cpu_warning")
+    crit_th=$(get_option "cpu_critical")
+    
+    local cpu_pct=""
+    
+    if is_macos; then
+        # macOS: top -l1 sample
+        cpu_pct=$(top -l1 2>/dev/null | awk '/^CPU usage/ {gsub(/%/,""); print $3}')
+    elif is_linux; then
+        # Linux: top -bn1 batch mode
+        cpu_pct=$(top -bn1 2>/dev/null | awk '/^%Cpu/ {gsub(/[^0-9.]/,"",$2); print $2}')
+    fi
+    
+    cpu_pct=$(extract_numeric "${cpu_pct:-0}")
+    
+    evaluate_threshold_health "$cpu_pct" "$warn_th" "$crit_th"
+}
+
+_collect_mem_health() {
+    local warn_th crit_th
+    warn_th=$(get_option "mem_warning")
+    crit_th=$(get_option "mem_critical")
+    
+    local mem_pct=""
+    
+    if is_macos; then
+        # macOS: memory_pressure
+        local free_pct
+        free_pct=$(memory_pressure 2>/dev/null | awk '/System-wide memory free percentage:/ {print $5}' | tr -d '%')
+        [[ -n "$free_pct" ]] && mem_pct=$((100 - free_pct))
+    elif is_linux; then
+        # Linux: /proc/meminfo
+        local mem_info
+        mem_info=$(awk '/^MemAvailable/ {avail=$2} /^MemTotal/ {total=$2} END {if (total>0) printf "%.0f", (total-avail)/total*100}' /proc/meminfo 2>/dev/null)
+        [[ -n "$mem_info" ]] && mem_pct="$mem_info"
+    fi
+    
+    mem_pct=$(extract_numeric "${mem_pct:-0}")
+    
+    evaluate_threshold_health "$mem_pct" "$warn_th" "$crit_th"
+}
+
+_collect_disk_health() {
+    local warn_th crit_th
+    warn_th=$(get_option "disk_warning")
+    crit_th=$(get_option "disk_critical")
+    
+    # Cross-platform: df -h /
+    local disk_pct
+    disk_pct=$(df / 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')
+    
+    disk_pct=$(extract_numeric "${disk_pct:-0}")
+    
+    evaluate_threshold_health "$disk_pct" "$warn_th" "$crit_th"
+}
+
+_collect_temp_health() {
+    local warn_th crit_th
+    warn_th=$(get_option "temp_warning")
+    crit_th=$(get_option "temp_critical")
+    
+    local temp_c=""
+    
+    if is_macos; then
+        # macOS: osx-cpu-temp or smctemp if available
+        if has_cmd "osx-cpu-temp"; then
+            temp_c=$(osx-cpu-temp 2>/dev/null | awk '{gsub(/°C/,""); print $1}')
+        elif has_cmd "smctemp"; then
+            temp_c=$(smctemp 2>/dev/null | awk '{print $2}')
+        fi
+    elif is_linux; then
+        # Linux: /sys/class/thermal/thermal_zone0/temp (millidegrees)
+        if [[ -f /sys/class/thermal/thermal_zone0/temp ]]; then
+            temp_c=$(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null)
+            temp_c=$((temp_c / 1000))
+        fi
+    fi
+    
+    # If no temp available, skip (don't affect health)
+    [[ -z "$temp_c" ]] && return 1
+    
+    evaluate_threshold_health "$temp_c" "$warn_th" "$crit_th"
+}
+
+# =============================================================================
+# Main Logic
+# =============================================================================
+
+plugin_collect() {
+    # Collect individual metrics and compute health
+    plugin_data_set "cpu_health" "$(_collect_cpu_health)"
+    plugin_data_set "mem_health" "$(_collect_mem_health)"
+    plugin_data_set "disk_health" "$(_collect_disk_health)"
+
+    local temp_health
+    temp_health=$(_collect_temp_health)
+    [[ -n "$temp_health" ]] && plugin_data_set "temp_health" "$temp_health"
+
+    # Always return 0 — temp sensor absence is not a failure
+    return 0
+}
+
+plugin_render() {
+    local format health
+    format=$(get_option "format")
+    health=$(plugin_get_health)
+    
+    case "$format" in
+        count)
+            local warn_count=0 crit_count=0
+            
+            [[ $(plugin_data_get "cpu_health") == "warning" ]] && ((warn_count++))
+            [[ $(plugin_data_get "cpu_health") == "error" ]] && ((crit_count++))
+            [[ $(plugin_data_get "mem_health") == "warning" ]] && ((warn_count++))
+            [[ $(plugin_data_get "mem_health") == "error" ]] && ((crit_count++))
+            [[ $(plugin_data_get "disk_health") == "warning" ]] && ((warn_count++))
+            [[ $(plugin_data_get "disk_health") == "error" ]] && ((crit_count++))
+            [[ $(plugin_data_get "temp_health") == "warning" ]] && ((warn_count++))
+            [[ $(plugin_data_get "temp_health") == "error" ]] && ((crit_count++))
+            
+            if (( crit_count > 0 )); then
+                printf '%d CRIT' "$crit_count"
+            elif (( warn_count > 0 )); then
+                printf '%d WARN' "$warn_count"
+            else
+                printf 'OK'
+            fi
+            ;;
+        detail)
+            # Show critical metrics only
+            local details=()
+            
+            [[ $(plugin_data_get "cpu_health") == "error" ]] && details+=("CPU CRIT")
+            [[ $(plugin_data_get "cpu_health") == "warning" ]] && details+=("CPU WARN")
+            [[ $(plugin_data_get "mem_health") == "error" ]] && details+=("MEM CRIT")
+            [[ $(plugin_data_get "mem_health") == "warning" ]] && details+=("MEM WARN")
+            [[ $(plugin_data_get "disk_health") == "error" ]] && details+=("DISK CRIT")
+            [[ $(plugin_data_get "disk_health") == "warning" ]] && details+=("DISK WARN")
+            [[ $(plugin_data_get "temp_health") == "error" ]] && details+=("TEMP CRIT")
+            [[ $(plugin_data_get "temp_health") == "warning" ]] && details+=("TEMP WARN")
+            
+            if [[ ${#details[@]} -eq 0 ]]; then
+                printf 'OK'
+            else
+                join_with_separator "|" "${details[@]}"
+            fi
+            ;;
+        badge|*)
+            case "$health" in
+                error)   printf 'CRIT' ;;
+                warning) printf 'WARN' ;;
+                *)       printf 'OK' ;;
+            esac
+            ;;
+    esac
+}

--- a/src/plugins/temperature.sh
+++ b/src/plugins/temperature.sh
@@ -368,26 +368,23 @@ plugin_get_context() {
 # =============================================================================
 
 plugin_get_icon() {
-    local health icon_warn icon_hot
+    local temperature warn_th crit_th
+    temperature=$(plugin_data_get "temp_c")
+    warn_th=$(get_option "warning_threshold")
+    crit_th=$(get_option "critical_threshold")
 
-    health=$(plugin_get_health)
-    icon_warn=$(get_option "icon_warning")
-    icon_hot=$(get_option "icon_hot")
-
-    case "$health" in
-        error)
-            [[ -n "$icon_hot" ]] && printf '%s' "$icon_hot" || get_option "icon"
-            return
-            ;;
-        warning)
-            [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
-            return
-            ;;
-        *)
-            get_option "icon"
-            return
-            ;;
-    esac
+    # Data-based icon selection (contract: icon must not call plugin_get_health)
+    if (( ${temperature:-0} >= ${crit_th:-85} )); then
+        local icon_hot
+        icon_hot=$(get_option "icon_hot")
+        [[ -n "$icon_hot" ]] && printf '%s' "$icon_hot" || get_option "icon"
+    elif (( ${temperature:-0} >= ${warn_th:-70} )); then
+        local icon_warn
+        icon_warn=$(get_option "icon_warning")
+        [[ -n "$icon_warn" ]] && printf '%s' "$icon_warn" || get_option "icon"
+    else
+        get_option "icon"
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/topproc.sh
+++ b/src/plugins/topproc.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Plugin: topproc
+# Description: Display the process consuming most CPU
+# Dependencies: ps (POSIX)
+# =============================================================================
+
+POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "${POWERKIT_ROOT}/src/contract/plugin_contract.sh"
+
+# =============================================================================
+# Plugin Contract: Metadata
+# =============================================================================
+
+plugin_get_metadata() {
+    metadata_set "id" "topproc"
+    metadata_set "name" "Top Process"
+    metadata_set "description" "Display the process consuming most CPU"
+}
+
+# =============================================================================
+# Plugin Contract: Dependencies
+# =============================================================================
+
+plugin_check_dependencies() {
+    # ps is POSIX - available on both macOS and Linux
+    has_cmd "ps" || return 1
+    return 0
+}
+
+# =============================================================================
+# Plugin Contract: Options
+# =============================================================================
+
+plugin_declare_options() {
+    declare_option "icon" "icon" $'\U000F0322' "Plugin icon (process)"
+    declare_option "warning_threshold" "number" "70" "Warning threshold (%)"
+    declare_option "critical_threshold" "number" "90" "Critical threshold (%)"
+    declare_option "max_length" "number" "15" "Max process name length"
+    declare_option "cache_ttl" "number" "5" "Cache duration in seconds"
+}
+
+# =============================================================================
+# Plugin Contract: Implementation
+# =============================================================================
+
+plugin_get_content_type() { printf 'dynamic'; }
+plugin_get_presence() { printf 'conditional'; }
+
+plugin_get_state() {
+    local proc_name
+    proc_name=$(plugin_data_get "proc_name")
+    [[ -n "$proc_name" ]] && printf 'active' || printf 'inactive'
+}
+
+plugin_get_health() {
+    local proc_pct warn_th crit_th
+    proc_pct=$(plugin_data_get "proc_pct")
+    warn_th=$(get_option "warning_threshold")
+    crit_th=$(get_option "critical_threshold")
+    
+    # Use extract_numeric to handle possible decimal values
+    proc_pct=$(extract_numeric "${proc_pct:-0}")
+    
+    evaluate_threshold_health "$proc_pct" "$warn_th" "$crit_th"
+}
+
+plugin_get_context() {
+    plugin_context_from_health "$(plugin_get_health)" "top_process"
+}
+
+plugin_get_icon() {
+    get_option "icon"
+}
+
+# =============================================================================
+# Main Logic
+# =============================================================================
+
+plugin_collect() {
+    local max_length
+    max_length=$(get_option "max_length")
+    
+    # POSIX-compliant: ps -A -o %cpu,comm
+    # Output: " 87.5 node" or " 10.2 python3"
+    local result
+    
+    # BSD/macOS and GNU ps both support -A -o %cpu,comm
+    # macOS returns full path for some procs (e.g. /usr/sbin/coreaudiod), extract basename
+    result=$(ps -A -o %cpu,comm 2>/dev/null | awk 'NR>1 {print $1, $2}' | sort -rn | head -1)
+
+    if [[ -n "$result" ]]; then
+        local proc_pct proc_name
+
+        # Parse: "87.5 /usr/sbin/coreaudiod" → proc_pct=87.5 proc_name=coreaudiod
+        proc_pct=$(echo "$result" | awk '{print $1}')
+        proc_name=$(echo "$result" | awk '{sub(/.*\//, "", $NF); print $NF}')
+
+        # Truncate process name
+        proc_name=$(truncate_text "$proc_name" "${max_length:-15}")
+
+        plugin_data_set "proc_pct" "$proc_pct"
+        plugin_data_set "proc_name" "$proc_name"
+        return 0
+    else
+        return 1
+    fi
+}
+
+plugin_render() {
+    local proc_name proc_pct
+    
+    proc_name=$(plugin_data_get "proc_name")
+    proc_pct=$(plugin_data_get "proc_pct")
+    
+    printf '%s %s%%' "$proc_name" "$proc_pct"
+}


### PR DESCRIPTION
Alert now triggers at 100% CPU saturation (load == n_cores) instead of 200%,
providing earlier warning of run-queue buildup. Critical threshold remains at 4x.