### PR TITLE
fix: Set fill color when building the message and command styles

### DIFF
--- a/src/renderer/styles.sh
+++ b/src/renderer/styles.sh
@@ -44,26 +44,34 @@ build_status_style() {
 
 # Build message style
 # Usage: build_message_style
-# Returns: "fg=COLOR,bg=COLOR"
+# Returns: "fg=COLOR,bg=COLOR,fill=COLOR"
 build_message_style() {
-    local bg fg
+    local fg bg fill
 
-    bg=$(resolve_color "message-bg")
     fg=$(resolve_color "message-fg")
 
-    printf 'fg=%s,bg=%s' "$fg" "$bg"
+    is_theme_loaded || load_powerkit_theme
+    bg=$(get_color "message-bg")
+    [[ -z "$bg" ]] && bg=$(resolve_color "message-bg")
+    fill="$bg"
+
+    printf 'fg=%s,bg=%s,fill=%s' "$fg" "$bg" "$fill"
 }
 
 # Build command message style
 # Usage: build_message_command_style
-# Returns: "fg=COLOR,bg=COLOR"
+# Returns: "fg=COLOR,bg=COLOR,fill=COLOR"
 build_message_command_style() {
-    local bg fg
+    local fg bg fill
 
-    bg=$(resolve_color "session-command-bg")
     fg=$(resolve_color "session-fg")
 
-    printf 'fg=%s,bg=%s' "$fg" "$bg"
+    is_theme_loaded || load_powerkit_theme
+    bg=$(get_color "session-command-bg")
+    [[ -z "$bg" ]] && bg=$(resolve_color "session-command-bg")
+    fill="$bg"
+
+    printf 'fg=%s,bg=%s,fill=%s' "$fg" "$bg" "$fill"
 }
 
 # =============================================================================


### PR DESCRIPTION
After updating to tmux version 3.7, I am seeing overlapping text when entering commands on the prompt.

<img width="431" height="34" alt="image" src="https://github.com/user-attachments/assets/dd64284e-10db-4b89-ad1c-f657f5d2bc62" />

The  message-style option now need to include "fill" in order to cover the whole width. This was a change in [tmux 3.7](https://raw.githubusercontent.com/tmux/tmux/3.7/CHANGES).

> Draw message as one format, allowing prompts and messages to occupy only a
  portion of the status bar, overlaying the normal status content rather than
  replacing the entire line. A new message-format option now controls the
  entire message (like status-format). The message-style option now need to
  include "fill" in order to cover the whole width (the default has
  "fill=yellow"). From Conor Taylor in issue 4861.

This PR updates the `build_message_style()` and `build_message_command_style()` functions to set and pass the fill colour to return the full width pre-tmux 3.7 status behaviour.

My tmux-powerkit related configuration provided below.

```shell
set -g @plugin 'fabioluciano/tmux-powerkit'
## theme settings
set -g @powerkit_theme "catppuccin-kristian"
set -g @powerkit_theme_variant "mocha"
set -g @powerkit_transparent "true"
## status bar settings
set -g @powerkit_status_position "bottom"
set -g @powerkit_status_order "session"
set -g @powerkit_separator_style "trapezoid"
set -g @powerkit_elements_spacing "true"
set -g @powerkit_icon_padding "2"
## window settings
set -g @powerkit_active_window_title "#W"
set -g @powerkit_inactive_window_title "#W"
set -g @powerkit_window_index_style "text"
## pane
set -g @powerkit_active_pane_border_color "#45475a"
```