### PR TITLE
fix: Add some settings to bring back old theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ set -g @powerkit_elements_spacing "both"  # false, true, both, windows, plugins
 
 ## ⚙️ Advanced Configuration
 
+### Session Customization
+
+You can customize the padding around the session text.
+
+```bash
+# Disable the padding space around the session name
+set -g @powerkit_session_padding "false"
+```
+
+
 ### Window Customization
 
 You can customize the text color of the active and inactive windows, as well as the padding around the window index. By default, text colors are automatically calculated based on the window's background color, and the index padding is enabled.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ set -g @powerkit_elements_spacing "both"  # false, true, both, windows, plugins
 
 ## ⚙️ Advanced Configuration
 
+### Plugin Customization
+
+You can control the edge separator background color when a plugin's icon is hidden (e.g. set to 'none'). By default, it uses the hidden icon's background color.
+
+```bash
+# Set the edge separator background to match the text content block instead of the icon block when the icon is hidden
+set -g @powerkit_plugin_no_icon_bg_style "content" # default is "icon"
+```
+
+
 ### Plugin-Specific Options
 
 Every plugin is highly customizable. Example with the `battery` plugin:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,20 @@ set -g @powerkit_elements_spacing "both"  # false, true, both, windows, plugins
 
 ## ⚙️ Advanced Configuration
 
+### Window Customization
+
+You can customize the text color of the active and inactive windows, as well as the padding around the window index. By default, text colors are automatically calculated based on the window's background color, and the index padding is enabled.
+
+```bash
+# Override automatic text color calculation
+set -g @powerkit_active_window_fg "white"
+set -g @powerkit_inactive_window_fg "#c0caf5"
+
+# Disable the padding space around the window index number
+set -g @powerkit_window_index_padding "false"
+```
+
+
 ### Plugin Customization
 
 You can control the edge separator background color when a plugin's icon is hidden (e.g. set to 'none'). By default, it uses the hidden icon's background color.

--- a/src/renderer/entities/session.sh
+++ b/src/renderer/entities/session.sh
@@ -49,6 +49,22 @@ _session_build_icon_condition() {
     icon_prefix=$(get_tmux_option "@powerkit_session_prefix_icon" "${POWERKIT_DEFAULT_SESSION_PREFIX_ICON}")
     icon_copy=$(get_tmux_option "@powerkit_session_copy_icon" "${POWERKIT_DEFAULT_SESSION_COPY_ICON}")
 
+    # Intelligently attach trailing space only if the icon renders visible content.
+    # This prevents double-spacing when icons are disabled by the user.
+    # Handles both truly empty strings and tmux conditionals that always evaluate
+    # to empty (e.g., "#{?0,,}" which bash sees as non-empty but tmux renders as "").
+    _session_icon_has_content() {
+        local val="$1"
+        [[ -z "$val" ]] && return 1
+        # Match tmux conditionals that always resolve to empty: #{?0,,}
+        local _empty_cond_re="^#\{\?[0-9]+,,\}$"
+        [[ "$val" =~ $_empty_cond_re ]] && return 1
+        return 0
+    }
+    _session_icon_has_content "$icon_prefix" && icon_prefix="${icon_prefix} "
+    _session_icon_has_content "$icon_copy" && icon_copy="${icon_copy} "
+    _session_icon_has_content "$icon_normal" && icon_normal="${icon_normal} "
+
     # Conditional: prefix mode -> prefix_icon, copy mode -> copy_icon, else -> normal_icon
     printf '#{?client_prefix,%s,#{?pane_in_mode,%s,%s}}' "$icon_prefix" "$icon_copy" "$icon_normal"
 }
@@ -99,14 +115,19 @@ session_render() {
     text_color=$(resolve_color "session-fg")
     show_mode=$(get_tmux_option "@powerkit_session_show_mode" "${POWERKIT_DEFAULT_SESSION_SHOW_MODE}")
 
+    local pad=" "
+    if [[ "$(get_tmux_option "@powerkit_session_padding" "true")" == "false" ]]; then
+        pad=""
+    fi
+
     # Build mode text if enabled
     if [[ "$show_mode" == "true" ]]; then
         mode_text=$(_session_build_mode_text)
         # Session content: bold text with mode text and mode-aware background
-        printf '#[fg=%s,bold,bg=%s] %s #S %s' "$text_color" "$bg_condition" "$icon_condition" "$mode_text"
+        printf '#[fg=%s,bold,bg=%s]%s%s#S%s%s' "$text_color" "$bg_condition" "$pad" "$icon_condition" "$pad" "$mode_text"
     else
         # Session content: bold text with mode-aware background (no mode display)
-        printf '#[fg=%s,bold,bg=%s] %s #S ' "$text_color" "$bg_condition" "$icon_condition"
+        printf '#[fg=%s,bold,bg=%s]%s%s#S%s' "$text_color" "$bg_condition" "$pad" "$icon_condition" "$pad"
     fi
 }
 

--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -67,7 +67,20 @@ _windows_get_colors() {
     local variant
     variant=$(get_contrast_variant "$base_color")
     index_fg=$(resolve_color "${base_color}-${variant}")
-    content_fg=$(resolve_color "${base_color}-${variant}")
+
+    local custom_fg
+    if [[ "$state" == "active" ]]; then
+        custom_fg=$(get_tmux_option "@powerkit_active_window_fg" "")
+    else
+        custom_fg=$(get_tmux_option "@powerkit_inactive_window_fg" "")
+    fi
+
+    if [[ -n "$custom_fg" ]]; then
+        content_fg=$(resolve_color "$custom_fg")
+        index_fg=$(resolve_color "$custom_fg")
+    else
+        content_fg=$(resolve_color "${base_color}-${variant}")
+    fi
 
     index_bg=$(resolve_color "${base_color}-lighter")
     content_bg=$(resolve_color "$base_color")
@@ -196,10 +209,15 @@ _windows_get_spacing_sep_char() {
 _windows_build_index_text() {
     local side="$1" index_fg="$2" index_bg="$3" style_attr="$4"
 
+    local pad=" "
+    if [[ "$(get_tmux_option "@powerkit_window_index_padding" "true")" == "false" ]]; then
+        pad=""
+    fi
+
     if [[ "$side" == "left" && -n "$_W_SEP_CHAR" ]]; then
-        printf '#[fg=%s,bg=%s%s] %s' "$index_fg" "$index_bg" "$style_attr" "$(window_get_index_display)"
+        printf '#[fg=%s,bg=%s%s]%s%s' "$index_fg" "$index_bg" "$style_attr" "$pad" "$(window_get_index_display)"
     else
-        printf '#[fg=%s,bg=%s%s]%s ' "$index_fg" "$index_bg" "$style_attr" "$(window_get_index_display)"
+        printf '#[fg=%s,bg=%s%s]%s%s' "$index_fg" "$index_bg" "$style_attr" "$(window_get_index_display)" "$pad"
     fi
 }
 

--- a/src/renderer/segment_builder.sh
+++ b/src/renderer/segment_builder.sh
@@ -323,6 +323,19 @@ render_plugin_segment() {
 
     local segment=""
 
+    local effective_bg
+    if [[ -n "$icon" && "$icon" != "none" ]]; then
+        effective_bg="$icon_bg"
+    else
+        local no_icon_bg_style
+        no_icon_bg_style=$(get_tmux_option "@powerkit_plugin_no_icon_bg_style" "icon")
+        if [[ "$no_icon_bg_style" == "content" ]]; then
+            effective_bg="$content_bg"
+        else
+            effective_bg="$icon_bg"
+        fi
+    fi
+
     # Opening separator logic depends on side and position
     if [[ "$side" == "left" ]]; then
         # Left side: plugins flow left-to-right with RIGHT separators (▶)
@@ -330,10 +343,10 @@ render_plugin_segment() {
         # Other plugins: normal right separator
         if [[ $is_first -eq 1 ]]; then
             # First plugin: small padding from edge
-            segment+="#[bg=${icon_bg}] "
+            segment+="#[bg=${effective_bg}] "
         else
             # Right-pointing (▶): fg=source (prev), bg=destination (icon)
-            segment+="#[fg=${prev_bg},bg=${icon_bg}]${_SEP_CACHE_RIGHT}#[none]"
+            segment+="#[fg=${prev_bg},bg=${effective_bg}]${_SEP_CACHE_RIGHT}#[none]"
         fi
     else
         # Right side: plugins flow right-to-left with LEFT separators (◀)
@@ -346,12 +359,12 @@ render_plugin_segment() {
             sep_opening="${_SEP_CACHE_LEFT}"
         fi
         # Left-pointing (◀): fg=destination (icon), bg=source (prev)
-        segment+="#[fg=${icon_bg},bg=${prev_bg}]${sep_opening}#[none]"
+        segment+="#[fg=${effective_bg},bg=${prev_bg}]${sep_opening}#[none]"
     fi
 
     # Icon section (no bold - icons don't need emphasis)
     # No left padding (separator provides visual space), only right padding
-    if [[ -n "$icon" ]]; then
+    if [[ -n "$icon" && "$icon" != "none" ]]; then
         segment+="#[fg=${icon_fg},bg=${icon_bg}]${icon} "
         # Internal separator between icon and content
         if [[ "$side" == "left" ]]; then


### PR DESCRIPTION
I recently updated my tmux plugins after not using them for a long time, and realized that this project had changed a lot. I missed the old style of my status bar, so I introduced some options that allowed me to bring back the old style:

<img width="1469" height="21" alt="image" src="https://github.com/user-attachments/assets/495d250e-8345-4b53-8c9a-284aebddde61" />

Please feel free to edit the added code as you see fit for your project. I just hope these are some helpful options.

### New Features & Customization Options

#### 1. Custom Window Text Colors
By default, the active and inactive window text colors are automatically derived from the background color's luminance. These new options allow users to explicitly override those colors.
- `@powerkit_active_window_fg` (e.g. `"white"`)
- `@powerkit_inactive_window_fg` (e.g. `"#c0caf5"`)

#### 2. Window Index Padding
The space around the window index number is now configurable. Disabling this removes the hardcoded space between the index and the window name.
- `@powerkit_window_index_padding` (default: `"true"`, can be set to `"false"`)

#### 3. Session Name Padding
The space around the session name and its icon is now configurable. It also intelligently prevents double-spacing when the session icon is explicitly hidden using tmux conditionals like `#{?0,,}`.
- `@powerkit_session_padding` (default: `"true"`, can be set to `"false"`)

#### 4. Plugin Edge Separator Behavior
When a plugin's icon is hidden (e.g. `set -g @powerkit_plugin_datetime_icon "none"`), the edge separator traditionally still matches the (now invisible) icon's background. This option allows the edge separator to match the content's background instead, creating a seamless visual flow.
- `@powerkit_plugin_no_icon_bg_style` (default: `"icon"`, can be set to `"content"`)

All new options default to their original hardcoded behaviors to ensure 100% backward compatibility.

----------------------
To achieve this style this is my powerkit setup right now:
```
set -g @powerkit_theme 'tokyo-night'
set -g @powerkit_theme_variant 'night'
set -g @powerkit_status_position 'bottom'
set -g @powerkit_separator_style 'normal'
set -g @powerkit_edge_separator_style 'normal'
set -g @powerkit_elements_spacing 'windows'
set -g @powerkit_active_window_fg 'white'
set -g @powerkit_window_index_padding 'false'
set -g @powerkit_active_window_icon ''
set -g @powerkit_session_icon "#{?0,,}"
set -g @powerkit_session_prefix_icon "#{?0,,}"
set -g @powerkit_session_copy_icon "#{?0,,}"
set -g @powerkit_plugins 'datetime'
set -g @powerkit_plugin_datetime_format 'time'
set -g @powerkit_plugin_datetime_icon 'none'
set -g @powerkit_plugin_no_icon_bg_style 'content'
run-shell '~/projects/tmux-powerkit/tmux-powerkit.tmux'
```