### PR TITLE
fix(windows): avoid recursive icon format overflow

### DIFF
--- a/src/contract/window_contract.sh
+++ b/src/contract/window_contract.sh
@@ -217,16 +217,19 @@ window_get_icon_format() {
     [[ -z "$default_icon" ]] && default_icon=$(get_tmux_option "@powerkit_window_default_icon" "$WINDOW_DEFAULT_ICON")
 
     # Build nested conditional format from the icon map
-    local format="$default_icon"
+    local command_pattern=""
+    local substitutions=""
     local cmd icon
 
     # Iterate through icon map (from registry.sh)
     for cmd in "${!WINDOW_ICON_MAP[@]}"; do
         icon="${WINDOW_ICON_MAP[$cmd]}"
-        format="#{?#{==:#{pane_current_command},$cmd},$icon,$format}"
+        command_pattern+="${command_pattern:+|}${cmd}"
+        substitutions+="${substitutions:+;}s|^${cmd}$|${icon}|"
     done
 
-    printf '%s' "$format"
+    printf '#{?#{m/r:^(%s)$,#{pane_current_command}},#{%s:pane_current_command},%s}' \
+        "$command_pattern" "$substitutions" "$default_icon"
 }
 
 # Simpler icon format (just returns default or custom)

--- a/tests/contract_window.bats
+++ b/tests/contract_window.bats
@@ -266,7 +266,7 @@ setup() {
 # window_get_icon_format
 # =============================================================================
 
-@test "window_get_icon_format returns non-empty conditional format" {
+@test "window_get_icon_format returns shallow command mapping format" {
     run bash -c '
         source "$1/src/core/bootstrap.sh"
         source "$1/src/contract/window_contract.sh"
@@ -274,9 +274,20 @@ setup() {
     ' _ "$POWERKIT_ROOT"
     assert_success
     refute_output ""
-    # Should contain pane_current_command conditionals
-    assert_output --partial '#{?#{=='
+    assert_output --partial '#{?#{m/r:'
+    assert_output --partial 's|^nvim$|'
     assert_output --partial '#{pane_current_command}'
+}
+
+@test "window_get_icon_format uses one conditional regardless of icon count" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/contract/window_contract.sh"
+        format=$(window_get_icon_format)
+        printf "%s\n" "$(grep -oF "#{?" <<<"$format" | wc -l | tr -d " ")"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output "1"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

With certain icons (nvim, claude, etc) in wezterm, the statusbar to the right side of the window containing the problematic icon continuously flickers between normal and blank. After some investigation, it appears to be related to the nested level of `format` expansion that tmux needs to handle when rendering the icon.

This PR changes how variable expansion is handled to reduce the nested levels. There are no behavior or appearance change of the statusbar.

## Changes

<!-- List of changes with their types (feat/fix/chore/refactor/etc.) -->

- **`fix(windows): avoid recursive icon format overflow`** - flatten `format` variable instead of recursive expansion

## Test Plan

<!-- How was this validated? -->

- [x] `bash tests/run_all_tests.sh` — passes
- [x] `tests/test_shellcheck.sh` — 0 warnings
- [x] `pre-commit validate-config` — passes
- [ ] CI matrix (ubuntu + macOS) — passes
- [ ] Manual smoke test of affected plugins

## Verification log

<!-- Paste command output here for reviewers -->

```text
$ bash tests/run_all_tests.sh
...
=== Summary ===

Plugins:   51 passed, 0 failed
Themes:    70 passed, 0 failed
Contracts: 3 passed, 0 failed
Utilities: 2 passed, 0 failed
Total:     126 passed, 0 failed

Contract validation PASSED

Result: ✓ PASS
...

$ shellcheck -S warning bin/ scripts/ tests/
...
=== Results ===
Total:  200
Passed: 200
Failed: 0

ShellCheck validation PASSED
```

## Out of scope / known follow-up

This has nothing to do with this PR, but one bats test failed on my side:
```
not ok 473 is_file_older_than returns 0 for a file older than threshold
# (from function `assert_success' in file tests/test_helper/bats-assert/src/assert_success.bash, line 45,
#  in test file tests/lib_filesystem.bats, line 384)
#   `assert_success' failed
#
# -- command failed --
# status : 1
# output :
# --
#
```
It happens because the test hard codes to use bsd tools syntax, while i have gnu coreutils on mac.

## Checklist

- [x] Branch is up-to-date with `main`
- [x] Commit messages follow Conventional Commits
- [x] No `Co-Authored-By` lines
- [x] No emoji in commit messages or PR title
- [x] All tests pass locally
- [x] No new shellcheck warnings introduced
- [x] Plugin contract still respected (data only, no UI logic)
- [x] Cross-platform impact considered (Linux + macOS)