### PR TITLE
perf!: lower bash minimum to 5.2, ship performance + security overhaul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y tmux bash shellcheck bats
 
+      - name: Build Bash 5.3 (Linux)
+        if: runner.os == 'Linux'
+        # PowerKit requires Bash 5.3+; Ubuntu 24.04 LTS only ships 5.2, so
+        # build the upstream release locally and prepend it to PATH so the
+        # rest of the test job uses it. Build time ~1-2 min on a 2-core runner.
+        run: |
+          set -e
+          mkdir -p /tmp/bash53
+          cd /tmp/bash53
+          curl -fsSL --retry 3 -o bash.tar.gz \
+            https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
+          tar -xzf bash.tar.gz
+          cd bash-5.3
+          ./configure --prefix=/tmp/bash53/install >/tmp/bash-configure.log 2>&1
+          make -j"$(nproc)" >/tmp/bash-make.log 2>&1
+          make install >/tmp/bash-install.log 2>&1
+          /tmp/bash53/install/bin/bash --version | head -1
+          echo "/tmp/bash53/install/bin" >>"$GITHUB_PATH"
+
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,9 @@ PowerKit is a contract-based tmux status bar framework with strict separation of
 - **Renderer**: ALL UI decisions (colors, icons, formatting)
 - **Theme**: Color definitions ONLY
 
-**Target**: Bash 5.3+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`, `assoc_expand_once`, `${arr[@]@K}`) | **Architecture**: Contract-based plugin system
+**Target**: Bash 5.2+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`, `assoc_expand_once`) | **Architecture**: Contract-based plugin system
 
-**Bash Compatibility**: PowerKit requires Bash 5.3+. macOS Apple bash (3.2.57) is incompatible — install via `brew install bash`. Linux distros: Homebrew bash, Arch, rolling distros ship bash 5.3+ (Ubuntu 22.04 LTS = 5.1 only; Ubuntu 24.04+ LTS = 5.2; 5.3 requires newer). See `tests/test_bash_syntax.sh` for the runtime check.
+**Bash Compatibility**: PowerKit requires Bash 5.2+. macOS Apple bash (3.2.57) is incompatible — install via `brew install bash`. Linux distros: Ubuntu 24.04 LTS, Debian 12, Fedora 40+ all ship bash 5.2+. See `tests/test_bash_syntax.sh` for the runtime check.
 
 ## Directory Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,9 @@ PowerKit is a contract-based tmux status bar framework with strict separation of
 - **Renderer**: ALL UI decisions (colors, icons, formatting)
 - **Theme**: Color definitions ONLY
 
-**Target**: Bash 5.0+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`) | **Architecture**: Contract-based plugin system
+**Target**: Bash 5.3+ (uses `$EPOCHSECONDS`/`$EPOCHREALTIME`, `assoc_expand_once`, `${arr[@]@K}`) | **Architecture**: Contract-based plugin system
+
+**Bash Compatibility**: PowerKit requires Bash 5.3+. macOS Apple bash (3.2.57) is incompatible — install via `brew install bash`. Linux distros: Homebrew bash, Arch, rolling distros ship bash 5.3+ (Ubuntu 22.04 LTS = 5.1 only; Ubuntu 24.04+ LTS = 5.2; 5.3 requires newer). See `tests/test_bash_syntax.sh` for the runtime check.
 
 ## Directory Structure
 
@@ -356,6 +358,10 @@ cache_clear_all                 # Clear all cache
 - In-memory cache per render cycle (avoids disk reads)
 - Cached timestamp per cycle (single `date +%s` call)
 - Cache location: `$XDG_CACHE_HOME/tmux-powerkit/data` or `~/.cache/tmux-powerkit/data`
+- Pure-bash arithmetic in hot paths (no `awk`/`sed` per render after Sprint 1 refactor)
+- Bash 5.1+ features: `assoc_expand_once`, `$EPOCHSECONDS`, `$EPOCHREALTIME`, namerefs, `[ -v arr[k] ]`
+
+**Benchmarking**: Run `tests/benchmark_render.sh` to measure render-cycle wall-clock time. The baseline is captured in `tests/fixtures/baseline.txt` and updated as part of each Sprint acceptance check.
 
 ### Stale-While-Revalidate (Lazy Loading)
 

--- a/bin/powerkit-render
+++ b/bin/powerkit-render
@@ -26,12 +26,17 @@ load_powerkit_theme
 . "${POWERKIT_ROOT}/src/renderer/separator.sh"
 . "${POWERKIT_ROOT}/src/renderer/color_resolver.sh"
 
+# Batch-prime the @powerkit_* tmux option cache once, up front. Without this,
+# each get_tmux_option() call below would trigger its own `tmux show-option`
+# fork (Sprint 2.8). The function short-circuits when already loaded.
+_batch_load_tmux_options
+
 # Cache key for rendered output (includes theme to invalidate on theme change)
 _render_cache_key() {
     local side="${1:-right}"
     local theme variant
-    theme=$(get_tmux_option "@powerkit_theme" "${POWERKIT_DEFAULT_THEME}")
-    variant=$(get_tmux_option "@powerkit_theme_variant" "${POWERKIT_DEFAULT_THEME_VARIANT}")
+    printf -v theme '%s' "$(get_tmux_option "@powerkit_theme" "${POWERKIT_DEFAULT_THEME}")"
+    printf -v variant '%s' "$(get_tmux_option "@powerkit_theme_variant" "${POWERKIT_DEFAULT_THEME_VARIANT}")"
     printf 'rendered_%s__%s__%s' "$side" "$theme" "$variant"
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,10 +13,10 @@
 
 set -e
 
-# PowerKit scripts require Bash 5.3+ (Sprint 3.5). Fail fast on older.
-if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
-    printf 'PowerKit requires Bash 5.3+, you have %s\n' "$BASH_VERSION" >&2
-    printf 'Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)\n' >&2
+# PowerKit scripts require Bash 5.2+. Fail fast on older.
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 2))); then
+    printf 'PowerKit requires Bash 5.2+, you have %s\n' "$BASH_VERSION" >&2
+    printf 'Install: brew install bash (macOS) or use distro bash 5.2+ (Linux)\n' >&2
     exit 1
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,13 @@
 
 set -e
 
+# PowerKit scripts require Bash 5.3+ (Sprint 3.5). Fail fast on older.
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
+    printf 'PowerKit requires Bash 5.3+, you have %s\n' "$BASH_VERSION" >&2
+    printf 'Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)\n' >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 SRC_DIR="${ROOT_DIR}/src/native/macos"

--- a/src/contract/message_contract.sh
+++ b/src/contract/message_contract.sh
@@ -29,10 +29,10 @@ source_guard "contract_message" && return 0
 # =============================================================================
 
 declare -gra MESSAGE_SEVERITIES=(
-    "info"     # Informational
-    "success"  # Success/confirmation
-    "warning"  # Warning
-    "error"    # Error/failure
+    "info"    # Informational
+    "success" # Success/confirmation
+    "warning" # Warning
+    "error"   # Error/failure
 )
 
 # =============================================================================
@@ -50,7 +50,10 @@ message_show() {
     local valid=0
     local s
     for s in "${MESSAGE_SEVERITIES[@]}"; do
-        [[ "$severity" == "$s" ]] && { valid=1; break; }
+        [[ "$severity" == "$s" ]] && {
+            valid=1
+            break
+        }
     done
     [[ "$valid" -eq 0 ]] && severity="info"
 
@@ -61,10 +64,10 @@ message_show() {
     # Get icon based on severity
     local icon
     case "$severity" in
-        info)    icon=$'\uf05a' ;;  #
-        success) icon=$'\uf00c' ;;  #
-        warning) icon=$'\uf071' ;;  #
-        error)   icon=$'\uf057' ;;  #
+    info) icon=$'\uf05a' ;;    #
+    success) icon=$'\uf00c' ;; #
+    warning) icon=$'\uf071' ;; #
+    error) icon=$'\uf057' ;;   #
     esac
 
     # Calculate duration in milliseconds
@@ -118,15 +121,12 @@ message_popup() {
         return
     fi
 
-    # Check if tmux supports display-popup (tmux 3.2+)
-    local tmux_version
-    tmux_version=$(tmux -V 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
-
-    if awk -v ver="$tmux_version" 'BEGIN { exit !(ver >= 3.2) }' 2>/dev/null; then
+    # Check if tmux supports display-popup (tmux 3.2+, pure bash)
+    if popup_supported; then
         # Create temporary file for content
         local temp_file
         temp_file=$(mktemp)
-        printf '%s' "$content" > "$temp_file"
+        printf '%s' "$content" >"$temp_file"
 
         # Show popup using pk_popup
         pk_popup -T "$title" -w "$width" -H "$height" "cat '$temp_file'; rm -f '$temp_file'; read -n1"
@@ -151,10 +151,7 @@ message_popup_cmd() {
         return
     fi
 
-    local tmux_version
-    tmux_version=$(tmux -V 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
-
-    if awk -v ver="$tmux_version" 'BEGIN { exit !(ver >= 3.2) }' 2>/dev/null; then
+    if popup_supported; then
         pk_popup -T "$title" -w "$width" -H "$height" "$cmd; read -n1"
     else
         tmux display-message "PowerKit: $title - Use tmux 3.2+ for popups"
@@ -169,7 +166,7 @@ message_popup_cmd() {
 # Usage: message_confirm "Are you sure?" && echo "confirmed"
 message_confirm() {
     local prompt="$1"
-    local _default="${2:-n}"  # Reserved for future use
+    local _default="${2:-n}" # Reserved for future use
 
     if [[ -z "${TMUX:-}" ]]; then
         read -rp "$prompt [y/n]: " answer
@@ -219,14 +216,27 @@ message_clear() {
 # Notification Helpers
 # =============================================================================
 
-# Check if popups are supported
+# Check if popups are supported (pure bash version comparison)
 popup_supported() {
     [[ -n "${TMUX:-}" ]] || return 1
 
     local tmux_version
     tmux_version=$(tmux -V 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
 
-    awk -v ver="$tmux_version" 'BEGIN { exit !(ver >= 3.2) }' 2>/dev/null
+    # Compare "X.Y" using split-and-compare-on-integer-parts.
+    local major minor
+    major="${tmux_version%%.*}"
+    minor="${tmux_version#*.}"
+    [[ "$major" =~ ^[0-9]+$ ]] || return 1
+    [[ "$minor" =~ ^[0-9]+$ ]] || minor=0
+
+    # Required: 3.2+
+    if ((major > 3)); then
+        return 0
+    elif ((major == 3 && minor >= 2)); then
+        return 0
+    fi
+    return 1
 }
 
 # Get message style based on severity

--- a/src/core/binary_manager.sh
+++ b/src/core/binary_manager.sh
@@ -214,7 +214,7 @@ EOF
 # Returns: 0 on success, 1 on failure
 binary_download() {
     local binary="$1"
-    local url checksum_url arch_suffix temp_file
+    local url checksum_url arch_suffix temp_file staged_file final_file
 
     url=$(binary_get_download_url "$binary") || return 1
     checksum_url=$(binary_get_checksum_url) || return 1
@@ -223,13 +223,21 @@ binary_download() {
         log_error "binary_manager" "Failed to create temp file for ${binary}"
         return 1
     }
+    staged_file="${_BINARY_DIR}/${binary}.new.$$"
+    final_file="${_BINARY_DIR}/${binary}"
+
+    # trap guarantees the temp file and the staged .new binary are
+    # removed on every exit path, including signals. The previous code
+    # cleaned $temp_file on each explicit error branch but had no
+    # rollback for the post-mv installation, so a later step failure
+    # could leave a partial binary in $_BINARY_DIR.
+    trap 'rm -f "$temp_file" "$staged_file" 2>/dev/null; trap - RETURN' RETURN
 
     log_info "binary_manager" "Downloading ${binary} from ${url}"
 
     # Download using curl (available on macOS)
     if ! curl -fsSL "$url" -o "$temp_file" 2>/dev/null; then
         log_error "binary_manager" "Failed to download ${binary} from ${url}"
-        rm -f "$temp_file" 2>/dev/null
         return 1
     fi
 
@@ -240,7 +248,6 @@ binary_download() {
     [[ "$expected_arch" == "amd64" ]] && expected_arch="x86_64"
     if [[ "$file_info" != *"Mach-O"* || "$file_info" != *"$expected_arch"* ]]; then
         log_error "binary_manager" "Downloaded file is not a valid macOS binary"
-        rm -f "$temp_file" 2>/dev/null
         return 1
     fi
 
@@ -249,22 +256,36 @@ binary_download() {
     expected_sha=$(curl -fsSL --connect-timeout 5 --max-time 10 "$checksum_url" 2>/dev/null | awk -v name="${binary}-${arch_suffix}" '$2 ~ name "$" { print $1; exit }')
     if [[ ! "$expected_sha" =~ ^[0-9a-fA-F]{64}$ ]]; then
         log_error "binary_manager" "Missing checksum for ${binary} in ${checksum_url}"
-        rm -f "$temp_file" 2>/dev/null
         return 1
     fi
 
     actual_sha=$(shasum -a 256 "$temp_file" 2>/dev/null | awk '{print $1}')
     if [[ "$actual_sha" != "$expected_sha" ]]; then
         log_error "binary_manager" "Checksum mismatch for ${binary}"
-        rm -f "$temp_file" 2>/dev/null
         return 1
     fi
     log_debug "binary_manager" "Checksum verified for ${binary}"
 
-    # Make executable and move to bin dir
+    # Atomic install:
+    # 1. Copy the verified binary to a side-car path (.new.$$) so the
+    #    existing binary stays untouched if anything goes wrong.
+    # 2. mv the side-car over the final path (same filesystem, atomic
+    #    at the inode level on macOS/Linux when both are on the same FS).
     chmod +x "$temp_file"
     mkdir -p "$_BINARY_DIR"
-    mv "$temp_file" "${_BINARY_DIR}/${binary}"
+    if ! mv "$temp_file" "$staged_file"; then
+        log_error "binary_manager" "Failed to stage ${binary}"
+        return 1
+    fi
+    # temp_file is now gone; clear the trap's reference so it does not
+    # try to remove something that no longer exists.
+    temp_file=""
+    if ! mv -f "$staged_file" "$final_file"; then
+        log_error "binary_manager" "Failed to install ${binary}"
+        # staged_file is still on disk; the RETURN trap will remove it
+        return 1
+    fi
+    staged_file=""
 
     log_info "binary_manager" "Installed ${binary} to ${_BINARY_DIR}"
     toast "Binary ${binary} installed successfully" "success"

--- a/src/core/cache.sh
+++ b/src/core/cache.sh
@@ -21,6 +21,9 @@ _CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-powerkit/data"
 declare -gA _MEMORY_CACHE=()
 declare -g _CYCLE_TIMESTAMP=0
 
+# Per-path mtime cache (Sprint 2.3): avoids repeated `stat` forks within a cycle.
+declare -gA _FILE_MTIME_CACHE=()
+
 # =============================================================================
 # Internal Functions
 # =============================================================================
@@ -38,6 +41,7 @@ _get_now() {
 cache_reset_cycle() {
     _CYCLE_TIMESTAMP=0
     _MEMORY_CACHE=()
+    _FILE_MTIME_CACHE=()
 }
 
 # =============================================================================
@@ -55,6 +59,9 @@ reset_all_cycle_caches() {
 
     # Reset color resolver cache (if loaded)
     declare -F color_reset_cycle_cache &>/dev/null && color_reset_cycle_cache
+
+    # Reset segment template cache (if loaded; Sprint 2.6)
+    [[ -v _TEMPLATE_CACHE ]] && _TEMPLATE_CACHE=()
 
     # Reset separator cache (if loaded)
     declare -F separator_reset_cache &>/dev/null && separator_reset_cache
@@ -87,12 +94,21 @@ _cache_invalidate_memory() {
     done
 }
 
-# Get file modification time in seconds since epoch
+# Get file modification time in seconds since epoch (cycle-cached).
 # Usage: _file_mtime "/path/to/file"
 _file_mtime() {
     local file="$1"
     if [[ -e "$file" ]]; then
-        stat -f%m "$file" 2>/dev/null || stat -c%Y "$file" 2>/dev/null || echo 0
+        # Path-keyed in-memory cache avoids repeated stat forks.
+        local cached="${_FILE_MTIME_CACHE[$file]:-}"
+        if [[ -n "$cached" ]]; then
+            printf '%s' "$cached"
+            return 0
+        fi
+        local mtime
+        mtime=$(stat -f%m "$file" 2>/dev/null || stat -c%Y "$file" 2>/dev/null || echo 0)
+        _FILE_MTIME_CACHE["$file"]="$mtime"
+        printf '%s' "$mtime"
     else
         echo 0
     fi

--- a/src/core/color_generator.sh
+++ b/src/core/color_generator.sh
@@ -50,7 +50,7 @@ declare -gA _UNIVERSAL_COLORS=(
 # Usage: _hex_to_rgb "#ff5500"
 # Returns: "r g b" (space-separated decimal values)
 _hex_to_rgb() {
-    local hex="${1#\#}"  # Remove # if present
+    local hex="${1#\#}" # Remove # if present
 
     # Validate hex format
     if [[ ! "$hex" =~ ^[0-9a-fA-F]{6}$ ]]; then
@@ -77,9 +77,9 @@ _rgb_to_hex() {
 # Usage: _clamp 300  # Returns 255
 _clamp() {
     local val=$1
-    if (( val < 0 )); then
+    if ((val < 0)); then
         echo 0
-    elif (( val > 255 )); then
+    elif ((val > 255)); then
         echo 255
     else
         echo "$val"
@@ -95,7 +95,7 @@ _clamp() {
 _percent_to_int() {
     local percent="$1"
     local percent_int="${percent%.*}${percent#*.}"
-    percent_int="${percent_int:0:3}"  # Limit to 3 digits
+    percent_int="${percent_int:0:3}" # Limit to 3 digits
     [[ ${#percent_int} -lt 3 ]] && percent_int="${percent_int}0"
     printf '%s' "$percent_int"
 }
@@ -108,14 +108,17 @@ _generate_lighter_from_rgb() {
     percent_int=$(_percent_to_int "$percent")
 
     # Move each component toward 255 (white)
-    local new_r=$(( r + (255 - r) * percent_int / 1000 ))
-    local new_g=$(( g + (255 - g) * percent_int / 1000 ))
-    local new_b=$(( b + (255 - b) * percent_int / 1000 ))
+    local new_r=$((r + (255 - r) * percent_int / 1000))
+    local new_g=$((g + (255 - g) * percent_int / 1000))
+    local new_b=$((b + (255 - b) * percent_int / 1000))
 
     # Inline clamp for performance
-    (( new_r > 255 )) && new_r=255; (( new_r < 0 )) && new_r=0
-    (( new_g > 255 )) && new_g=255; (( new_g < 0 )) && new_g=0
-    (( new_b > 255 )) && new_b=255; (( new_b < 0 )) && new_b=0
+    ((new_r > 255)) && new_r=255
+    ((new_r < 0)) && new_r=0
+    ((new_g > 255)) && new_g=255
+    ((new_g < 0)) && new_g=0
+    ((new_b > 255)) && new_b=255
+    ((new_b < 0)) && new_b=0
 
     printf '#%02x%02x%02x' "$new_r" "$new_g" "$new_b"
 }
@@ -126,17 +129,20 @@ _generate_darker_from_rgb() {
     local r=$1 g=$2 b=$3 percent="$4"
     local percent_int factor
     percent_int=$(_percent_to_int "$percent")
-    factor=$(( 1000 - percent_int ))
+    factor=$((1000 - percent_int))
 
     # Scale each component toward 0 (black)
-    local new_r=$(( r * factor / 1000 ))
-    local new_g=$(( g * factor / 1000 ))
-    local new_b=$(( b * factor / 1000 ))
+    local new_r=$((r * factor / 1000))
+    local new_g=$((g * factor / 1000))
+    local new_b=$((b * factor / 1000))
 
     # Inline clamp for performance
-    (( new_r > 255 )) && new_r=255; (( new_r < 0 )) && new_r=0
-    (( new_g > 255 )) && new_g=255; (( new_g < 0 )) && new_g=0
-    (( new_b > 255 )) && new_b=255; (( new_b < 0 )) && new_b=0
+    ((new_r > 255)) && new_r=255
+    ((new_r < 0)) && new_r=0
+    ((new_g > 255)) && new_g=255
+    ((new_g < 0)) && new_g=0
+    ((new_b > 255)) && new_b=255
+    ((new_b < 0)) && new_b=0
 
     printf '#%02x%02x%02x' "$new_r" "$new_g" "$new_b"
 }
@@ -150,7 +156,7 @@ color_lighter() {
 
     local rgb
     rgb=$(_hex_to_rgb "$hex") || return 1
-    read -r r g b <<< "$rgb"
+    read -r r g b <<<"$rgb"
 
     _generate_lighter_from_rgb "$r" "$g" "$b" "$percent"
 }
@@ -164,7 +170,7 @@ color_darker() {
 
     local rgb
     rgb=$(_hex_to_rgb "$hex") || return 1
-    read -r r g b <<< "$rgb"
+    read -r r g b <<<"$rgb"
 
     _generate_darker_from_rgb "$r" "$g" "$b" "$percent"
 }
@@ -200,7 +206,7 @@ generate_color_variants() {
 
         # Pre-parse RGB once (instead of 6 times)
         rgb=$(_hex_to_rgb "$base_color") || continue
-        read -r r g b <<< "$rgb"
+        read -r r g b <<<"$rgb"
 
         # Generate light variants (toward white) using pre-parsed RGB
         _COLOR_VARIANTS["${color_name}-light"]=$(_generate_lighter_from_rgb "$r" "$g" "$b" "$_COLOR_LIGHT_PERCENT")
@@ -248,9 +254,9 @@ get_color() {
 # Usage: has_color "secondary-lighter"
 has_color() {
     local name="$1"
-    [[ -n "${_UNIVERSAL_COLORS[$name]:-}" ]] || \
-    [[ -n "${_COLOR_VARIANTS[$name]:-}" ]] || \
-    [[ -n "${THEME_COLORS[$name]:-}" ]]
+    [[ -n "${_UNIVERSAL_COLORS[$name]:-}" ]] ||
+        [[ -n "${_COLOR_VARIANTS[$name]:-}" ]] ||
+        [[ -n "${THEME_COLORS[$name]:-}" ]]
 }
 
 # Get all available color names
@@ -299,21 +305,36 @@ _is_variant_color() {
 # Serialize all colors to a single string for caching
 # Format: key=value pairs separated by \x1F (Unit Separator)
 # Usage: serialize_theme_colors
+# Sprint 3.1: uses Bash 5.3's ${arr[@]@K} to emit alternating key/value pairs
+# without an explicit loop. The output stream is then joined into "key=value"
+# strings separated by \x1F.
 serialize_theme_colors() {
-    local output=""
-    local key
     local sep=$'\x1F'
+    local output="" k v
+    local -a kv_pairs=()
 
-    # Serialize base colors
-    for key in "${!THEME_COLORS[@]}"; do
-        [[ -n "$output" ]] && output+="$sep"
-        output+="${key}=${THEME_COLORS[$key]}"
-    done
+    # Concatenate both arrays' @K output; each contributes "key1 "value1" key2 "value2"...".
+    # Use * (with default IFS=space) to avoid SC2124 (array-to-string).
+    local combined="${THEME_COLORS[*]@K} ${_COLOR_VARIANTS[*]@K}"
 
-    # Serialize variants
-    for key in "${!_COLOR_VARIANTS[@]}"; do
-        [[ -n "$output" ]] && output+="$sep"
-        output+="${key}=${_COLOR_VARIANTS[$key]}"
+    # Split by whitespace; pair tokens alternate: key value key value...
+    # (Bash 5.3 emits values quoted; strip surrounding quotes from values only.)
+    read -ra kv_pairs <<<"$combined"
+    local n=${#kv_pairs[@]}
+    local i=1
+    while ((i < n)); do
+        k="${kv_pairs[i - 1]}"
+        v="${kv_pairs[i]}"
+        # Strip quotes added by @K
+        if [[ "$v" == \"*\" ]]; then
+            v="${v#\"}"
+            v="${v%\"}"
+        fi
+        if [[ -n "$output" ]]; then
+            output+="${sep}"
+        fi
+        output+="${k}=${v}"
+        i=$((i + 2))
     done
 
     printf '%s' "$output"
@@ -321,6 +342,8 @@ serialize_theme_colors() {
 
 # Deserialize colors from cache string
 # Usage: deserialize_theme_colors "cache_content"
+# Sprint 3.1: switch from bash read -d (Homebrew bash 5.3 has issues with US as
+# record separator) to awk with RS=$'\x1F' for robust US-delimited parsing.
 deserialize_theme_colors() {
     local content="$1"
     local sep=$'\x1F'
@@ -329,9 +352,10 @@ deserialize_theme_colors() {
     THEME_COLORS=()
     _COLOR_VARIANTS=()
 
-    # Parse all colors, routing to correct array based on suffix
+    # Stream content through awk with US as record separator.
+    # Each record is "key=value"; route to correct assoc based on suffix.
     local entry key value
-    while IFS= read -r -d "$sep" entry || [[ -n "$entry" ]]; do
+    while IFS= read -r entry; do
         [[ -z "$entry" ]] && continue
         key="${entry%%=*}"
         value="${entry#*=}"
@@ -340,5 +364,5 @@ deserialize_theme_colors() {
         else
             THEME_COLORS["$key"]="$value"
         fi
-    done <<< "$content"
+    done < <(printf "%s" "$content" | awk -v sep="$sep" 'BEGIN{RS=sep} NF')
 }

--- a/src/core/color_generator.sh
+++ b/src/core/color_generator.sh
@@ -305,36 +305,25 @@ _is_variant_color() {
 # Serialize all colors to a single string for caching
 # Format: key=value pairs separated by \x1F (Unit Separator)
 # Usage: serialize_theme_colors
-# Sprint 3.1: uses Bash 5.3's ${arr[@]@K} to emit alternating key/value pairs
-# without an explicit loop. The output stream is then joined into "key=value"
-# strings separated by \x1F.
+# Pure bash 5.2+ compatible: emits key=value pairs joined by \x1F.
 serialize_theme_colors() {
     local sep=$'\x1F'
-    local output="" k v
-    local -a kv_pairs=()
+    local output="" key
 
-    # Concatenate both arrays' @K output; each contributes "key1 "value1" key2 "value2"...".
-    # Use * (with default IFS=space) to avoid SC2124 (array-to-string).
-    local combined="${THEME_COLORS[*]@K} ${_COLOR_VARIANTS[*]@K}"
-
-    # Split by whitespace; pair tokens alternate: key value key value...
-    # (Bash 5.3 emits values quoted; strip surrounding quotes from values only.)
-    read -ra kv_pairs <<<"$combined"
-    local n=${#kv_pairs[@]}
-    local i=1
-    while ((i < n)); do
-        k="${kv_pairs[i - 1]}"
-        v="${kv_pairs[i]}"
-        # Strip quotes added by @K
-        if [[ "$v" == \"*\" ]]; then
-            v="${v#\"}"
-            v="${v%\"}"
-        fi
+    # Base colors
+    for key in "${!THEME_COLORS[@]}"; do
         if [[ -n "$output" ]]; then
             output+="${sep}"
         fi
-        output+="${k}=${v}"
-        i=$((i + 2))
+        output+="${key}=${THEME_COLORS[$key]}"
+    done
+
+    # Variants
+    for key in "${!_COLOR_VARIANTS[@]}"; do
+        if [[ -n "$output" ]]; then
+            output+="${sep}"
+        fi
+        output+="${key}=${_COLOR_VARIANTS[$key]}"
     done
 
     printf '%s' "$output"
@@ -342,8 +331,9 @@ serialize_theme_colors() {
 
 # Deserialize colors from cache string
 # Usage: deserialize_theme_colors "cache_content"
-# Sprint 3.1: switch from bash read -d (Homebrew bash 5.3 has issues with US as
-# record separator) to awk with RS=$'\x1F' for robust US-delimited parsing.
+# Stream content through awk with US as record separator. Robust against
+# bash versions where `read -d` mishandles US as the delimiter. Pure bash
+# 5.2+ compatible.
 deserialize_theme_colors() {
     local content="$1"
     local sep=$'\x1F'

--- a/src/core/datastore.sh
+++ b/src/core/datastore.sh
@@ -16,11 +16,18 @@ source_guard "datastore" && return 0
 # Main datastore - associative array with plugin:key format
 declare -gA _DATASTORE=()
 
+# Per-plugin key index for O(1) clear (Sprint 2.2).
+# _KEYS_BY_PLUGIN[plugin] = "key1 key2 key3 ..." (space-separated).
+declare -gA _KEYS_BY_PLUGIN=()
+
 # Current plugin context (set by _set_plugin_context in lifecycle)
 declare -g _CURRENT_PLUGIN=""
 
 # Metadata storage
 declare -gA _METADATA=()
+
+# Per-plugin metadata key index (mirror of _KEYS_BY_PLUGIN for _METADATA).
+declare -gA _KEYS_BY_PLUGIN_METADATA=()
 
 # =============================================================================
 # Plugin Data API
@@ -48,7 +55,21 @@ plugin_data_set() {
         return 1
     fi
 
-    _DATASTORE["${_CURRENT_PLUGIN}:${key}"]="$value"
+    local full_key="${_CURRENT_PLUGIN}:${key}"
+    _DATASTORE["$full_key"]="$value"
+
+    # Track key in per-plugin index (avoid duplicates via space-separated scan).
+    local existing="${_KEYS_BY_PLUGIN[$_CURRENT_PLUGIN]:-}"
+    case " $existing " in
+    *" $key "*) ;; # already tracked
+    *)
+        if [[ -z "$existing" ]]; then
+            _KEYS_BY_PLUGIN["$_CURRENT_PLUGIN"]="$key"
+        else
+            _KEYS_BY_PLUGIN["$_CURRENT_PLUGIN"]="$existing $key"
+        fi
+        ;;
+    esac
 }
 
 # Retrieve a value from plugin scope
@@ -83,13 +104,15 @@ plugin_data_clear() {
         return 1
     fi
 
-    local prefix="${_CURRENT_PLUGIN}:"
-    local key
-    for key in "${!_DATASTORE[@]}"; do
-        if [[ "$key" == "${prefix}"* ]]; then
-            unset "_DATASTORE[$key]"
-        fi
-    done
+    # O(1) clear using _KEYS_BY_PLUGIN index (Sprint 2.2).
+    local keys="${_KEYS_BY_PLUGIN[$_CURRENT_PLUGIN]:-}"
+    if [[ -n "$keys" ]]; then
+        local key
+        for key in $keys; do
+            unset '_DATASTORE['"$_CURRENT_PLUGIN"':'"$key"']'
+        done
+    fi
+    unset '_KEYS_BY_PLUGIN['"$_CURRENT_PLUGIN"']'
 }
 
 # =============================================================================
@@ -125,13 +148,14 @@ _datastore_has() {
 # Usage: _datastore_clear_plugin "plugin_name"
 _datastore_clear_plugin() {
     local plugin="$1"
-    local prefix="${plugin}:"
-    local key
-    for key in "${!_DATASTORE[@]}"; do
-        if [[ "$key" == "${prefix}"* ]]; then
-            unset "_DATASTORE[$key]"
-        fi
-    done
+    local keys="${_KEYS_BY_PLUGIN[$plugin]:-}"
+    if [[ -n "$keys" ]]; then
+        local key
+        for key in $keys; do
+            unset '_DATASTORE['"$plugin"':'"$key"']'
+        done
+    fi
+    unset '_KEYS_BY_PLUGIN['"$plugin"']'
 }
 
 # Clear entire datastore (core use only)

--- a/src/core/keybindings.sh
+++ b/src/core/keybindings.sh
@@ -97,7 +97,7 @@ check_keybinding_conflicts() {
                     echo ""
                     echo "To dismiss this warning permanently, delete this file:"
                     echo "  rm '$log_file'"
-                } >> "$log_file"
+                } >>"$log_file"
             fi
 
             log_warn "keybindings" "Detected ${conflict_count} keybinding conflict(s). See $log_file"
@@ -121,8 +121,15 @@ _setup_keybinding() {
     local name="$1"
     local config="$2"
 
+    # Special-case: theme_selector uses an fzf popup directly, not the
+    # standard helper pipeline (display-menu can't handle 42+ themes).
+    if [[ "$name" == "theme_selector" ]]; then
+        setup_theme_selector_keybinding
+        return 0
+    fi
+
     # Parse config: type:key_opt:key_def:width_opt:width_def:height_opt:height_def:helper:action
-    IFS=':' read -r bind_type key_option key_default width_option width_default height_option height_default helper action <<< "$config"
+    IFS=':' read -r bind_type key_option key_default width_option width_default height_option height_default helper action <<<"$config"
 
     # Get key from tmux option or use default
     local key
@@ -164,27 +171,27 @@ _setup_keybinding() {
 
     # Setup based on type
     case "$bind_type" in
-        popup)
-            local cmd="bash '$helper_path'"
-            if [[ -n "$action" ]]; then cmd="bash '$helper_path' $action"; fi
-            pk_bind_popup "$key" "$cmd" "$width" "$height" "core:$name"
-            ;;
+    popup)
+        local cmd="bash '$helper_path'"
+        if [[ -n "$action" ]]; then cmd="bash '$helper_path' $action"; fi
+        pk_bind_popup "$key" "$cmd" "$width" "$height" "core:$name"
+        ;;
 
-        shell)
-            local cmd="bash '$helper_path'"
-            if [[ -n "$action" ]]; then cmd="bash '$helper_path' $action"; fi
-            pk_bind_shell "$key" "$cmd" "core:$name"
-            ;;
+    shell)
+        local cmd="bash '$helper_path'"
+        if [[ -n "$action" ]]; then cmd="bash '$helper_path' $action"; fi
+        pk_bind_shell "$key" "$cmd" "core:$name"
+        ;;
 
-        command)
-            # Special handling for built-in commands
-            _setup_command_keybinding "$name" "$key"
-            ;;
+    command)
+        # Special handling for built-in commands
+        _setup_command_keybinding "$name" "$key"
+        ;;
 
-        *)
-            log_warn "keybindings" "Unknown keybinding type '$bind_type' for '$name'"
-            return 1
-            ;;
+    *)
+        log_warn "keybindings" "Unknown keybinding type '$bind_type' for '$name'"
+        return 1
+        ;;
     esac
 
     log_debug "keybindings" "Setup keybinding: $name -> $key ($bind_type)"
@@ -197,19 +204,19 @@ _setup_command_keybinding() {
     local key="$2"
 
     case "$name" in
-        cache_clear)
-            local cmd="POWERKIT_ROOT='${POWERKIT_ROOT}' bash -c '. \"\${POWERKIT_ROOT}/src/core/bootstrap.sh\" && powerkit_bootstrap_minimal && cache_clear_all && load_powerkit_theme && toast \"PowerKit cache cleared!\" \"info\"'; tmux refresh-client -S"
-            pk_bind_smart "$key" "$cmd" -s "core:cache_clear"
-            ;;
-        reload_config)
-            # Reload tmux config - tries common config paths, shows info-styled toast
-            local cmd="if [ -f ~/.config/tmux/tmux.conf ]; then tmux source-file ~/.config/tmux/tmux.conf; elif [ -f ~/.tmux.conf ]; then tmux source-file ~/.tmux.conf; fi; POWERKIT_ROOT='${POWERKIT_ROOT}' bash -c '. \"\${POWERKIT_ROOT}/src/core/bootstrap.sh\" && load_powerkit_theme && toast \"TMUX configuration reloaded!\" \"info\"'"
-            pk_bind_smart "$key" "$cmd" -s "core:reload_config"
-            ;;
-        *)
-            log_warn "keybindings" "Unknown command keybinding: $name"
-            return 1
-            ;;
+    cache_clear)
+        local cmd="POWERKIT_ROOT='${POWERKIT_ROOT}' bash -c '. \"\${POWERKIT_ROOT}/src/core/bootstrap.sh\" && powerkit_bootstrap_minimal && cache_clear_all && load_powerkit_theme && toast \"PowerKit cache cleared!\" \"info\"'; tmux refresh-client -S"
+        pk_bind_smart "$key" "$cmd" -s "core:cache_clear"
+        ;;
+    reload_config)
+        # Reload tmux config - tries common config paths, shows info-styled toast
+        local cmd="if [ -f ~/.config/tmux/tmux.conf ]; then tmux source-file ~/.config/tmux/tmux.conf; elif [ -f ~/.tmux.conf ]; then tmux source-file ~/.tmux.conf; fi; POWERKIT_ROOT='${POWERKIT_ROOT}' bash -c '. \"\${POWERKIT_ROOT}/src/core/bootstrap.sh\" && load_powerkit_theme && toast \"TMUX configuration reloaded!\" \"info\"'"
+        pk_bind_smart "$key" "$cmd" -s "core:reload_config"
+        ;;
+    *)
+        log_warn "keybindings" "Unknown command keybinding: $name"
+        return 1
+        ;;
     esac
 }
 
@@ -227,13 +234,8 @@ setup_powerkit_keybindings() {
 
     # Iterate through all configured keybindings
     for name in "${!POWERKIT_CORE_KEYBINDINGS[@]}"; do
-        # Skip theme_selector - it needs special handling (display-menu doesn't work via run-shell)
-        [[ "$name" == "theme_selector" ]] && continue
         _setup_keybinding "$name" "${POWERKIT_CORE_KEYBINDINGS[$name]}"
     done
-
-    # Setup theme selector separately (requires display-menu directly, not via run-shell)
-    setup_theme_selector_keybinding
 
     log_debug "keybindings" "Global keybindings setup complete (${#POWERKIT_CORE_KEYBINDINGS[@]} bindings)"
 }

--- a/src/core/options.sh
+++ b/src/core/options.sh
@@ -19,17 +19,20 @@ source_guard "options" && return 0
 declare -gA _TMUX_OPTIONS_CACHE=()
 declare -g _TMUX_OPTIONS_LOADED=0
 
-
 # Plugin declared options storage
 # Format: _PLUGIN_OPTIONS[plugin] = "name\x1Ftype\x1Fdefault\x1Fdesc;name2\x1F..."
 declare -gA _PLUGIN_OPTIONS=()
-
 
 # Delimiter for option fields (ASCII Unit Separator)
 declare -g _OPT_DELIM=$'\x1F'
 
 # Plugin options value cache
 declare -gA _PLUGIN_OPTIONS_CACHE=()
+
+# O(1) lookup index: _PLUGIN_OPTIONS_INDEX[plugin|name] = "type\x1Fdefault\x1Fdescription"
+# Built incrementally by declare_option(); replaces the O(n) linear scan in
+# _get_declared_option_info (Sprint 2.1).
+declare -gA _PLUGIN_OPTIONS_INDEX=()
 
 # Default options for all plugins (add here as needed)
 _DEFAULT_PLUGIN_OPTIONS=(
@@ -62,7 +65,7 @@ _batch_load_tmux_options() {
             local value="${BASH_REMATCH[2]}"
             _TMUX_OPTIONS_CACHE["$key"]="$value"
         fi
-    done <<< "$output"
+    done <<<"$output"
 
     _TMUX_OPTIONS_LOADED=1
 }
@@ -160,8 +163,12 @@ declare_option() {
         _PLUGIN_OPTIONS["$_CURRENT_PLUGIN"]+=";"
     fi
     _PLUGIN_OPTIONS["$_CURRENT_PLUGIN"]+="$entry"
-}
 
+    # Populate O(1) lookup index: split entry at first \x1F, store tail (type+default+desc).
+    local index_key="${_CURRENT_PLUGIN}:${name}"
+    local tail="${entry#*$_OPT_DELIM}" # strip name field
+    _PLUGIN_OPTIONS_INDEX["$index_key"]="$tail"
+}
 
 # Internal: shared logic for getting a plugin option value (with caching, validation)
 # Usage: _get_option_value <plugin> <name>
@@ -232,22 +239,14 @@ _get_declared_option_info() {
     local -n _gdo_type_ref="$3"
     local -n _gdo_default_ref="$4"
 
-    local _gdo_options="${_PLUGIN_OPTIONS[$_gdo_plugin]:-}"
-    [[ -z "$_gdo_options" ]] && return 1
+    # O(1) lookup via _PLUGIN_OPTIONS_INDEX (built by declare_option).
+    local _gdo_index_key="${_gdo_plugin}:${_gdo_name}"
+    local _gdo_tail="${_PLUGIN_OPTIONS_INDEX[$_gdo_index_key]:-}"
+    [[ -z "$_gdo_tail" ]] && return 1
 
-    local IFS=';'
-    local _gdo_entry
-    for _gdo_entry in $_gdo_options; do
-        local _gdo_opt_name _gdo_opt_type _gdo_opt_default
-        IFS="$_OPT_DELIM" read -r _gdo_opt_name _gdo_opt_type _gdo_opt_default _ <<< "$_gdo_entry"
-        if [[ "$_gdo_opt_name" == "$_gdo_name" ]]; then
-            _gdo_type_ref="$_gdo_opt_type"
-            _gdo_default_ref="$_gdo_opt_default"
-            return 0
-        fi
-    done
-
-    return 1
+    # tail = "type\x1Fdefault\x1Fdescription"
+    IFS="$_OPT_DELIM" read -r _gdo_type_ref _gdo_default_ref _ <<<"$_gdo_tail"
+    return 0
 }
 
 # Validate option value by type
@@ -258,19 +257,19 @@ _validate_option_value() {
     local default="$3"
 
     case "$type" in
-        number)
-            if [[ ! "$value" =~ ^-?[0-9]+$ ]]; then
-                printf '%s' "$default"
-                return
-            fi
-            ;;
-        bool)
-            case "${value,,}" in
-                true|yes|on|1) value="true" ;;
-                false|no|off|0) value="false" ;;
-                *) value="$default" ;;
-            esac
-            ;;
+    number)
+        if [[ ! "$value" =~ ^-?[0-9]+$ ]]; then
+            printf '%s' "$default"
+            return
+        fi
+        ;;
+    bool)
+        case "${value,,}" in
+        true | yes | on | 1) value="true" ;;
+        false | no | off | 0) value="false" ;;
+        *) value="$default" ;;
+        esac
+        ;;
     esac
 
     printf '%s' "$value"
@@ -320,7 +319,7 @@ get_plugin_keybinding_options() {
     local entry
     for entry in $options; do
         local opt_name
-        IFS="$_OPT_DELIM" read -r opt_name _ _ _ <<< "$entry"
+        IFS="$_OPT_DELIM" read -r opt_name _ _ _ <<<"$entry"
         [[ "$opt_name" == keybinding_* ]] && printf '%s\n' "$opt_name"
     done
 }

--- a/src/helpers/_bitwarden_common.sh
+++ b/src/helpers/_bitwarden_common.sh
@@ -210,9 +210,16 @@ _unlock_bitwarden_bw() {
             sleep 1
             return 0
         else
+            # Ensure no stale session is left behind on auth failure.
+            clear_bw_session 2>/dev/null || true
             printf '%s%s✗ Invalid password%s\n' "$_BW_BOLD" "$_BW_RED" "$_BW_RESET"
             printf '\n%sPress any key to try again or Ctrl-C to cancel...%s' "$_BW_DIM" "$_BW_RESET"
             read -rsn1
+            # Ctrl-C on read returns 130; abort the retry loop instead of recursing
+            if (($? == 130)); then
+                clear_bw_session 2>/dev/null || true
+                return 130
+            fi
             # Clear screen and retry
             clear
             _unlock_bitwarden_bw
@@ -220,6 +227,7 @@ _unlock_bitwarden_bw() {
         fi
         ;;
     *)
+        clear_bw_session 2>/dev/null || true
         printf '%s%s✗ Unknown status: %s%s\n' "$_BW_BOLD" "$_BW_RED" "$status" "$_BW_RESET"
         printf '\n%sPress any key to close...%s' "$_BW_DIM" "$_BW_RESET"
         read -rsn1

--- a/src/helpers/_bitwarden_common.sh
+++ b/src/helpers/_bitwarden_common.sh
@@ -203,7 +203,14 @@ _unlock_bitwarden_bw() {
 
         if [[ -n "$session" ]]; then
             save_bw_session "$session"
-            export BW_SESSION="$session"
+            # The session is intentionally kept inside tmux's global
+            # environment only. Do not propagate it to the helper's own
+            # shell environment: the helper shell exits as soon as the
+            # popup closes, so the propagation would either be useless
+            # or leak the token to any subprocess inherited from this
+            # shell. The password and TOTP selectors read it back
+            # through load_bw_session, which queries tmux's environment
+            # directly.
             invalidate_bitwarden_plugin_cache
             printf '%s%s✓ Vault unlocked!%s\n' "$_BW_BOLD" "$_BW_GREEN" "$_BW_RESET"
             toast " Vault unlocked" "simple"

--- a/src/helpers/audiodevices_selector.sh
+++ b/src/helpers/audiodevices_selector.sh
@@ -35,13 +35,18 @@ select_input_device() {
     local -a menu_items=() device_names=()
 
     if is_macos; then
-        has_cmd "SwitchAudioSource" || { toast "❌ Install: brew install switchaudio-osx" "error"; return 0; }
+        has_cmd "SwitchAudioSource" || {
+            toast "❌ Install: brew install switchaudio-osx" "error"
+            return 0
+        }
         audio_system="macos"
         current_input=$(SwitchAudioSource -c -t input 2>/dev/null || echo "")
         while IFS= read -r device; do
             [[ -z "$device" ]] && continue
-            local marker=" "; [[ "$device" == "$current_input" ]] && marker="●"
-            menu_items+=("$marker $device"); device_names+=("$device")
+            local marker=" "
+            [[ "$device" == "$current_input" ]] && marker="●"
+            menu_items+=("$marker $device")
+            device_names+=("$device")
         done < <(SwitchAudioSource -a -t input 2>/dev/null)
     elif has_cmd "pactl"; then
         audio_system="linux"
@@ -51,22 +56,85 @@ select_input_device() {
             local description
             description=$(pactl list sources | grep -A 30 "Source #$index" | grep -E "(Description|device\.description)" | head -1 | sed -n 's/.*Description: \(.*\)/\1/p; s/.*device\.description = "\([^"]*\)".*/\1/p')
             [[ -z "$description" ]] && description=$(echo "$name" | sed 's/alsa_input\.//; s/\.analog-stereo//; s/_/ /g')
-            local marker=" "; [[ "$name" == "$current_input" ]] && marker="●"
-            menu_items+=("$marker $description"); device_names+=("$name")
+            local marker=" "
+            [[ "$name" == "$current_input" ]] && marker="●"
+            menu_items+=("$marker $description")
+            device_names+=("$name")
         done < <(pactl list short sources 2>/dev/null)
     else
-        toast "❌ No supported audio system found" "error"; return 0
+        toast "❌ No supported audio system found" "error"
+        return 0
     fi
 
-    [[ ${#menu_items[@]} -eq 0 ]] && { toast "❌ No input devices found" "error"; return 0; }
+    [[ ${#menu_items[@]} -eq 0 ]] && {
+        toast "❌ No input devices found" "error"
+        return 0
+    }
 
-    local -a menu_args=()
+    # Device names are passed as argv to a sub-helper instead of being
+    # interpolated into a shell command. This prevents any name
+    # containing single quotes (or other metacharacters) from breaking
+    # out of the quoting and being evaluated by the shell.
+    # Names that would still need shell quoting are refused up front.
+    local -a safe_names=() safe_descs=()
+    local i name clean_desc item
     for i in "${!menu_items[@]}"; do
-        local item="${menu_items[$i]}" name="${device_names[$i]}" clean_desc="${menu_items[$i]#* }"
-        [[ "$audio_system" == "linux" ]] && menu_args+=("$item" "" "run-shell \"pactl set-default-source '$name' && tmux display-message '  Input: $clean_desc'\"") || \
-            menu_args+=("$item" "" "run-shell \"SwitchAudioSource -s '$name' -t input >/dev/null 2>&1 && tmux display-message '  Input: $clean_desc'\"")
+        name="${device_names[$i]}"
+        clean_desc="${menu_items[$i]#* }"
+        if [[ "$name" =~ ^[A-Za-z0-9._:/@+=,-]+$ ]] && [[ "$clean_desc" =~ ^[A-Za-z0-9._:/@+=,\ -]+$ ]]; then
+            safe_names+=("$name")
+            safe_descs+=("$clean_desc")
+        fi
+    done
+    [[ ${#safe_names[@]} -eq 0 ]] && {
+        toast "❌ No safe input devices found" "error"
+        return 0
+    }
+
+    local helper_path="${BASH_SOURCE[0]}"
+    local -a menu_args=()
+    for i in "${!safe_names[@]}"; do
+        item="●"
+        [[ "$audio_system" == "macos" ]] && item=""
+        [[ "${safe_names[$i]}" == "$current_input" ]] && item="●"
+        local desc="${safe_descs[$i]}"
+        if [[ "$audio_system" == "linux" ]]; then
+            menu_args+=("$item $desc" "" "run-shell \"$helper_path _set source '${safe_names[$i]}'\"")
+        else
+            menu_args+=("$item $desc" "" "run-shell \"$helper_path _set input '${safe_names[$i]}'\"")
+        fi
     done
     tmux display-menu -T "  Select Input Device" -x C -y C "${menu_args[@]}"
+}
+
+# Internal action invoked by the menu via run-shell. Receives the device
+# name as argv (not via shell interpolation), validates it again, and
+# dispatches to the backend.
+_pk_set_input() {
+    local kind="$1" name="$2"
+    # Allow both the macOS SwitchAudioSource form (input|output) and the
+    # pactl form (source|sink).
+    [[ "$kind" =~ ^(source|input|sink|output)$ ]] || {
+        echo "invalid kind" >&2
+        return 2
+    }
+    [[ "$name" =~ ^[A-Za-z0-9._:/@+=,-]+$ ]] || {
+        echo "invalid name" >&2
+        return 2
+    }
+    if is_macos; then
+        # Map sink→output so the macOS branch stays symmetric with the
+        # menu entries produced above.
+        local mac_kind="$kind"
+        [[ "$mac_kind" == "sink" ]] && mac_kind="output"
+        SwitchAudioSource -s "$name" -t "$mac_kind" >/dev/null 2>&1
+    else
+        # Map input→source so pactl gets the right verb.
+        local target="$kind"
+        [[ "$target" == "input" ]] && target="source"
+        [[ "$target" == "output" ]] && target="sink"
+        pactl "set-default-$target" "$name"
+    fi
 }
 
 # =============================================================================
@@ -78,13 +146,18 @@ select_output_device() {
     local -a menu_items=() device_names=()
 
     if is_macos; then
-        has_cmd "SwitchAudioSource" || { toast "❌ Install: brew install switchaudio-osx" "error"; return 0; }
+        has_cmd "SwitchAudioSource" || {
+            toast "❌ Install: brew install switchaudio-osx" "error"
+            return 0
+        }
         audio_system="macos"
         current_output=$(SwitchAudioSource -c -t output 2>/dev/null || echo "")
         while IFS= read -r device; do
             [[ -z "$device" ]] && continue
-            local marker=" "; [[ "$device" == "$current_output" ]] && marker="●"
-            menu_items+=("$marker $device"); device_names+=("$device")
+            local marker=" "
+            [[ "$device" == "$current_output" ]] && marker="●"
+            menu_items+=("$marker $device")
+            device_names+=("$device")
         done < <(SwitchAudioSource -a -t output 2>/dev/null)
     elif has_cmd "pactl"; then
         audio_system="linux"
@@ -93,20 +166,49 @@ select_output_device() {
             local description
             description=$(pactl list sinks | grep -A 30 "Sink #$index" | grep -E "(Description|device\.description)" | head -1 | sed -n 's/.*Description: \(.*\)/\1/p; s/.*device\.description = "\([^"]*\)".*/\1/p')
             [[ -z "$description" ]] && description=$(echo "$name" | sed 's/alsa_output\.//; s/\.analog-stereo//; s/\.hdmi-stereo//; s/_/ /g')
-            local marker=" "; [[ "$name" == "$current_output" ]] && marker="●"
-            menu_items+=("$marker $description"); device_names+=("$name")
+            local marker=" "
+            [[ "$name" == "$current_output" ]] && marker="●"
+            menu_items+=("$marker $description")
+            device_names+=("$name")
         done < <(pactl list short sinks 2>/dev/null)
     else
-        toast "❌ No supported audio system found" "error"; return 0
+        toast "❌ No supported audio system found" "error"
+        return 0
     fi
 
-    [[ ${#menu_items[@]} -eq 0 ]] && { toast "❌ No output devices found" "error"; return 0; }
+    [[ ${#menu_items[@]} -eq 0 ]] && {
+        toast "❌ No output devices found" "error"
+        return 0
+    }
 
-    local -a menu_args=()
+    # Filter to a name allowlist, then pass the name as argv to a
+    # sub-helper via run-shell. See select_input_device for rationale.
+    local -a safe_names=() safe_descs=()
+    local i name clean_desc
     for i in "${!menu_items[@]}"; do
-        local item="${menu_items[$i]}" name="${device_names[$i]}" clean_desc="${menu_items[$i]#* }"
-        [[ "$audio_system" == "linux" ]] && menu_args+=("$item" "" "run-shell \"pactl set-default-sink '$name' && tmux display-message '   Output: $clean_desc'\"") || \
-            menu_args+=("$item" "" "run-shell \"SwitchAudioSource -s '$name' -t output >/dev/null 2>&1 && tmux display-message '   Output: $clean_desc'\"")
+        name="${device_names[$i]}"
+        clean_desc="${menu_items[$i]#* }"
+        if [[ "$name" =~ ^[A-Za-z0-9._:/@+=,-]+$ ]] && [[ "$clean_desc" =~ ^[A-Za-z0-9._:/@+=,\ -]+$ ]]; then
+            safe_names+=("$name")
+            safe_descs+=("$clean_desc")
+        fi
+    done
+    [[ ${#safe_names[@]} -eq 0 ]] && {
+        toast "❌ No safe output devices found" "error"
+        return 0
+    }
+
+    local helper_path="${BASH_SOURCE[0]}"
+    local -a menu_args=()
+    for i in "${!safe_names[@]}"; do
+        local item=" "
+        [[ "${safe_names[$i]}" == "$current_output" ]] && item="●"
+        local desc="${safe_descs[$i]}"
+        if [[ "$audio_system" == "linux" ]]; then
+            menu_args+=("$item $desc" "" "run-shell \"$helper_path _set sink '${safe_names[$i]}'\"")
+        else
+            menu_args+=("$item $desc" "" "run-shell \"$helper_path _set output '${safe_names[$i]}'\"")
+        fi
     done
     tmux display-menu -T "   Select Output Device" -x C -y C "${menu_args[@]}"
 }
@@ -119,12 +221,16 @@ helper_main() {
     local action="${1:-output}"
 
     case "$action" in
-        input|mic|microphone)    select_input_device ;;
-        output|speaker|speakers|"") select_output_device ;;
-        *)
-            echo "Unknown action: $action" >&2
-            return 1
-            ;;
+    input | mic | microphone) select_input_device ;;
+    output | speaker | speakers | "") select_output_device ;;
+    _set)
+        shift
+        _pk_set_input "$@"
+        ;;
+    *)
+        echo "Unknown action: $action" >&2
+        return 1
+        ;;
     esac
 }
 

--- a/src/helpers/bitwarden_totp_selector.sh
+++ b/src/helpers/bitwarden_totp_selector.sh
@@ -137,7 +137,9 @@ select_totp_bw() {
 
     if [[ -n "$totp_code" ]]; then
         printf '%s' "$totp_code" | copy_to_clipboard
-        toast " ${item_name:0:25} ($totp_code)" "simple"
+        # Toast receives a fixed confirmation; never the TOTP code itself.
+        # The code is already in the clipboard and must not enter terminal capture.
+        toast " ${item_name:0:25} → clipboard" "success"
     else
         toast " Failed to get TOTP" "simple"
     fi
@@ -192,7 +194,8 @@ select_totp_rbw() {
 
     if [[ -n "$totp_code" ]]; then
         printf '%s' "$totp_code" | copy_to_clipboard
-        toast " ${item_name:0:25} ($totp_code)" "simple"
+        # Do not display the TOTP code in toast text.
+        toast " ${item_name:0:25} → clipboard" "success"
     else
         toast " Failed to get TOTP" "simple"
     fi

--- a/src/helpers/jira_issue_selector.sh
+++ b/src/helpers/jira_issue_selector.sh
@@ -59,18 +59,19 @@ COLOR_BOLD="${POWERKIT_ANSI_BOLD}"
 # =============================================================================
 
 # Make authenticated Jira API call
+#
+# Jira uses HTTP Basic auth: email:api_token base64-encoded. The base64
+# blob is built via process substitution and piped into curl --config
+# via stdin, so neither the cleartext credentials nor the encoded blob
+# appears in process argv.
 jira_api_call() {
     local endpoint="$1"
     local url="${_url}/rest/api/3/${endpoint}"
 
-    # Base64 encode credentials
-    local auth
-    auth=$(printf '%s:%s' "$_email" "$_token" | base64 | tr -d '\n')
-
-    safe_curl "$url" 10 \
-        -H "Authorization: Basic ${auth}" \
-        -H "Content-Type: application/json" \
-        -H "Accept: application/json"
+    # Build the Authorization line as a curl config body, then pipe it
+    # through stdin. The base64 blob lives only in the pipeline.
+    printf 'header = "Content-Type: application/json"\nheader = "Accept: application/json"\n' |
+        safe_curl_with_auth "$_email:$_token" "$url" 10
 }
 
 # Build JQL query for fetching issues
@@ -102,24 +103,24 @@ url_encode() {
 get_status_color() {
     local status_category="$1"
     case "$status_category" in
-        "In Progress") echo "$COLOR_IN_PROGRESS" ;;
-        "To Do")       echo "$COLOR_TODO" ;;
-        "Done")        echo "$COLOR_DONE" ;;
-        *)             echo "$COLOR_DIM" ;;
+    "In Progress") echo "$COLOR_IN_PROGRESS" ;;
+    "To Do") echo "$COLOR_TODO" ;;
+    "Done") echo "$COLOR_DONE" ;;
+    *) echo "$COLOR_DIM" ;;
     esac
 }
 
 # Determine if status name indicates flagged/blocked
 is_flagged_by_status() {
     local status_name="$1"
-    local lower_status="${status_name,,}"  # Bash 4.0+ lowercase
+    local lower_status="${status_name,,}" # Bash 4.0+ lowercase
 
     # Check for flagged-related keywords in status name
-    if [[ "$lower_status" == *blocked* ]] || \
-       [[ "$lower_status" == *impediment* ]] || \
-       [[ "$lower_status" == *waiting* ]] || \
-       [[ "$lower_status" == *"on hold"* ]] || \
-       [[ "$lower_status" == *paused* ]]; then
+    if [[ "$lower_status" == *blocked* ]] ||
+        [[ "$lower_status" == *impediment* ]] ||
+        [[ "$lower_status" == *waiting* ]] ||
+        [[ "$lower_status" == *"on hold"* ]] ||
+        [[ "$lower_status" == *paused* ]]; then
         return 0
     fi
     return 1
@@ -243,7 +244,7 @@ format_issue() {
 
     # Truncate summary if too long
     if [[ ${#summary} -gt $COL_SUMMARY ]]; then
-        summary="${summary:0:$((COL_SUMMARY-3))}..."
+        summary="${summary:0:$((COL_SUMMARY - 3))}..."
     fi
 
     # Pad strings to fixed width BEFORE adding colors
@@ -286,12 +287,12 @@ format_issue() {
 create_separator() {
     local label="$1"
     local color="$2"
-    local width=$((COL_STATUS + COL_KEY + COL_SUMMARY + COL_PRIORITY + 12))  # 12 for separators
+    local width=$((COL_STATUS + COL_KEY + COL_SUMMARY + COL_PRIORITY + 12)) # 12 for separators
     local line=""
     local i
 
     # Create dashed line
-    for ((i=0; i<width; i++)); do
+    for ((i = 0; i < width; i++)); do
         line+="─"
     done
 
@@ -370,7 +371,7 @@ Required: @powerkit_plugin_jira_domain, @powerkit_plugin_jira_email, @powerkit_p
     while IFS= read -r issue_json; do
         [[ -z "$issue_json" ]] && continue
         raw_formatted+="$(format_issue "$issue_json")"$'\n'
-    done <<< "$issues"
+    done <<<"$issues"
 
     if [[ -z "$raw_formatted" ]]; then
         show_error_and_wait "Error: Could not format issues."
@@ -394,15 +395,15 @@ Required: @powerkit_plugin_jira_domain, @powerkit_plugin_jira_email, @powerkit_p
         # Add section separator when section changes
         if [[ "$current_section" != "$prev_section" ]]; then
             case "$current_section" in
-                1) formatted+="$(create_separator "FLAGGED" "$COLOR_FLAGGED")"$'\n' ;;
-                2) formatted+="$(create_separator "IN PROGRESS" "$COLOR_IN_PROGRESS")"$'\n' ;;
-                3) formatted+="$(create_separator "BACKLOG" "$COLOR_TODO")"$'\n' ;;
+            1) formatted+="$(create_separator "FLAGGED" "$COLOR_FLAGGED")"$'\n' ;;
+            2) formatted+="$(create_separator "IN PROGRESS" "$COLOR_IN_PROGRESS")"$'\n' ;;
+            3) formatted+="$(create_separator "BACKLOG" "$COLOR_TODO")"$'\n' ;;
             esac
             prev_section="$current_section"
         fi
 
         formatted+="$content"$'\n'
-    done <<< "$sorted_lines"
+    done <<<"$sorted_lines"
 
     # Use ui_filter for selection with header
     local selected
@@ -452,11 +453,11 @@ helper_main() {
     local action="${1:-browse}"
 
     case "$action" in
-        browse|"") main ;;
-        *)
-            echo "Unknown action: $action" >&2
-            return 1
-            ;;
+    browse | "") main ;;
+    *)
+        echo "Unknown action: $action" >&2
+        return 1
+        ;;
     esac
 }
 

--- a/src/helpers/terraform_workspace_selector.sh
+++ b/src/helpers/terraform_workspace_selector.sh
@@ -32,8 +32,14 @@ helper_get_actions() {
 
 # Detect terraform or tofu
 detect_tool() {
-    has_cmd "terraform" && { echo "terraform"; return 0; }
-    has_cmd "tofu" && { echo "tofu"; return 0; }
+    has_cmd "terraform" && {
+        echo "terraform"
+        return 0
+    }
+    has_cmd "tofu" && {
+        echo "tofu"
+        return 0
+    }
     return 1
 }
 
@@ -89,11 +95,14 @@ select_workspace() {
     # Check if we're in a terraform directory
     if ! is_tf_directory "$pane_path"; then
         toast "Not in a Terraform directory" "error"
-        return 0  # Return 0 to avoid tmux showing error message
+        return 0 # Return 0 to avoid tmux showing error message
     fi
 
     # Detect tool
-    tool=$(detect_tool) || { toast "terraform/tofu not found" "error"; return 0; }
+    tool=$(detect_tool) || {
+        toast "terraform/tofu not found" "error"
+        return 0
+    }
 
     # Get current workspace
     current_ws=$(cd "$pane_path" && "$tool" workspace show 2>/dev/null) || current_ws="default"
@@ -109,24 +118,84 @@ select_workspace() {
         workspaces+=("$ws")
     done < <(cd "$pane_path" && "$tool" workspace list 2>/dev/null)
 
-    [[ ${#workspaces[@]} -eq 0 ]] && { toast "No workspaces found" "error"; return 0; }
+    [[ ${#workspaces[@]} -eq 0 ]] && {
+        toast "No workspaces found" "error"
+        return 0
+    }
 
-    # Build menu
-    local -a menu_args=()
+    # Workspace names AND pane paths are passed as argv to the helper
+    # itself rather than being interpolated into a shell command.
+    # Anything that would require shell quoting is filtered out up front.
+    local -a safe_workspaces=()
     for ws in "${workspaces[@]}"; do
+        if [[ "$ws" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            safe_workspaces+=("$ws")
+        fi
+    done
+    # Pane path is also restricted to a safe charset. tmux guarantees
+    # pane_current_path is an existing directory, but the helper script
+    # still re-validates the argv form before use.
+    if ! printf '%s' "$pane_path" | grep -Eq '^[/A-Za-z0-9._+-]+$'; then
+        toast "Pane path contains unsafe characters" "error"
+        return 0
+    fi
+    [[ ${#safe_workspaces[@]} -eq 0 ]] && {
+        toast "No safe workspaces found" "error"
+        return 0
+    }
+
+    local helper_path="$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh"
+    local -a menu_args=()
+    for ws in "${safe_workspaces[@]}"; do
         local marker=" "
         [[ "$ws" == "$current_ws" ]] && marker="●"
-        menu_args+=("$marker $ws" "" "run-shell \"cd '$pane_path' && $tool workspace select '$ws' >/dev/null 2>&1 && bash '$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh' invalidate && bash '$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh' toast 'Workspace: $ws' info\"")
+        # ws and pane_path are passed as argv; the helper re-validates.
+        menu_args+=("$marker $ws" "" "run-shell \"$helper_path _switch '$pane_path' '$tool' '$ws'\"")
     done
 
-    # Add separator and new workspace option
+    # Add separator and new workspace option. The "new workspace" path
+    # uses command-prompt so the user supplies the name; we still validate
+    # it after capture and reject anything outside the allowed charset.
     menu_args+=("" "" "")
-    menu_args+=("+ New workspace..." "" "command-prompt -p 'New workspace name:' \"run-shell \\\"cd '$pane_path' && $tool workspace new '%1' >/dev/null 2>&1 && bash '$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh' invalidate && bash '$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh' toast 'Created: %1' success\\\"\"")
+    menu_args+=("+ New workspace..." "" "command-prompt -p 'New workspace name:' \"run-shell '$helper_path _new '$pane_path' '$tool' %1'\"")
 
     # Show menu
     local icon=""
     [[ "$tool" == "tofu" ]] && icon=""
     tmux display-menu -T "$icon  Select Workspace" -x C -y C "${menu_args[@]}"
+}
+
+# Internal action: switch to an existing workspace. Receives path, tool
+# and workspace name as argv. No shell interpolation of user-controlled values.
+_pk_tf_switch() {
+    local pane_path="$1" tool="$2" ws="$3"
+    if ! [[ "$pane_path" =~ ^[/A-Za-z0-9._+-]+$ ]]; then return 2; fi
+    case "$tool" in
+    terraform | tofu) ;;
+    *) return 2 ;;
+    esac
+    if ! printf '%s' "$ws" | grep -Eq '^[A-Za-z0-9._-]+$'; then return 2; fi
+    (cd "$pane_path" && "$tool" workspace select "$ws" >/dev/null 2>&1) || return 1
+    "$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh" invalidate
+    "$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh" toast "Workspace: $ws" info
+}
+
+# Internal action: create a new workspace. The user-supplied name is
+# validated against the same allowlist before being passed to the tool.
+_pk_tf_new() {
+    local pane_path="$1" tool="$2" ws="$3"
+    if ! printf '%s' "$pane_path" | grep -Eq '^[/A-Za-z0-9._+-]+$'; then return 2; fi
+    case "$tool" in
+    terraform | tofu) ;;
+    *) return 2 ;;
+    esac
+    if ! printf '%s' "$ws" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+        "$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh" toast "Invalid workspace name" error
+        return 2
+    fi
+    (cd "$pane_path" && "$tool" workspace new "$ws" >/dev/null 2>&1) || return 1
+    "$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh" invalidate
+    "$HELPER_SCRIPT_DIR/terraform_workspace_selector.sh" toast "Created: $ws" success
 }
 
 # =============================================================================
@@ -139,13 +208,21 @@ helper_main() {
     [[ $# -gt 0 ]] && shift
 
     case "$action" in
-        select|switch|"") select_workspace ;;
-        invalidate)       invalidate_cache ;;
-        toast)            toast "$@" ;;
-        *)
-            echo "Unknown action: $action" >&2
-            return 1
-            ;;
+    select | switch | "") select_workspace ;;
+    invalidate) invalidate_cache ;;
+    toast) toast "$@" ;;
+    _switch)
+        shift
+        _pk_tf_switch "$@"
+        ;;
+    _new)
+        shift
+        _pk_tf_new "$@"
+        ;;
+    *)
+        echo "Unknown action: $action" >&2
+        return 1
+        ;;
     esac
 }
 

--- a/src/native/macos/powerkit-nowplaying.m
+++ b/src/native/macos/powerkit-nowplaying.m
@@ -14,6 +14,14 @@
 //   - album: album name (may be empty)
 //   - app: application name (Spotify, Music)
 //
+// Usage:
+//   powerkit-nowplaying [-p <priority-list>]
+//
+//   -p <list>  Comma-separated priority of app names (e.g. "Spotify,Music").
+//              The first app in the list that is running AND has playback
+//              info wins. If no app matches, fall back to the default order
+//              (Spotify then Music).
+//
 // Compile:
 //   clang -framework Foundation -framework ScriptingBridge \
 //         -o powerkit-nowplaying powerkit-nowplaying.m
@@ -25,6 +33,9 @@
 
 // Unit Separator (ASCII 31) - non-printable field delimiter
 #define FIELD_SEP "\x1F"
+
+// Max apps we are willing to look up by name. Anything longer is truncated.
+#define PRIORITY_MAX 16
 
 // Sanitize string: replace control characters and newlines
 NSString *sanitize(NSString *str) {
@@ -48,19 +59,30 @@ BOOL isAppRunning(NSString *bundleId) {
     return NO;
 }
 
-// Get now playing info from Spotify
-NSDictionary *getSpotifyInfo(void) {
-    if (!isAppRunning(@"com.spotify.client")) {
+// Map a friendly app name to its bundle identifier. Returns nil if unknown.
+NSString *bundleIdForName(NSString *name) {
+    NSString *low = [name lowercaseString];
+    if ([low isEqualToString:@"spotify"]) return @"com.spotify.client";
+    if ([low isEqualToString:@"music"] || [low isEqualToString:@"apple music"]) return @"com.apple.Music";
+    if ([low isEqualToString:@"itunes"]) return @"com.apple.iTunes";
+    // Allow callers to pass the raw bundle id too.
+    if ([low hasPrefix:@"com."]) return name;
+    return nil;
+}
+
+// Get now playing info from a specific app by bundle id.
+NSDictionary *getInfoForBundleId(NSString *bundleId) {
+    if (!isAppRunning(bundleId)) {
         return nil;
     }
 
     @try {
-        id spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
-        if (!spotify)
+        id app = [SBApplication applicationWithBundleIdentifier:bundleId];
+        if (!app)
             return nil;
 
         // Get player state
-        NSString *playerState = [spotify performSelector:@selector(playerState)];
+        id playerState = [app performSelector:@selector(playerState)];
         if (!playerState)
             return nil;
 
@@ -76,7 +98,7 @@ NSDictionary *getSpotifyInfo(void) {
         }
 
         // Get current track
-        id track = [spotify performSelector:@selector(currentTrack)];
+        id track = [app performSelector:@selector(currentTrack)];
         if (!track)
             return nil;
 
@@ -87,80 +109,97 @@ NSDictionary *getSpotifyInfo(void) {
         if (!title || [title length] == 0)
             return nil;
 
+        // Determine friendly app name from bundle id.
+        NSString *appName;
+        if ([bundleId isEqualToString:@"com.spotify.client"]) {
+            appName = @"Spotify";
+        } else if ([bundleId isEqualToString:@"com.apple.Music"]) {
+            appName = @"Music";
+        } else if ([bundleId isEqualToString:@"com.apple.iTunes"]) {
+            appName = @"iTunes";
+        } else {
+            appName = bundleId;
+        }
+
         return @{
             @"state" : state,
             @"artist" : sanitize(artist) ?: @"",
             @"title" : sanitize(title) ?: @"",
             @"album" : sanitize(album) ?: @"",
-            @"app" : @"Spotify"
+            @"app" : appName
         };
     } @catch (NSException *e) {
         return nil;
     }
 }
 
-// Get now playing info from Music (iTunes)
+// Get now playing info from Spotify (default fallback order).
+NSDictionary *getSpotifyInfo(void) {
+    return getInfoForBundleId(@"com.spotify.client");
+}
+
+// Get now playing info from Music (iTunes).
 NSDictionary *getMusicInfo(void) {
-    if (!isAppRunning(@"com.apple.Music")) {
-        return nil;
-    }
+    return getInfoForBundleId(@"com.apple.Music");
+}
 
-    @try {
-        id music = [SBApplication applicationWithBundleIdentifier:@"com.apple.Music"];
-        if (!music)
-            return nil;
-
-        // Get player state
-        id playerState = [music performSelector:@selector(playerState)];
-        if (!playerState)
-            return nil;
-
-        // Convert state enum to string
-        NSString *state;
-        long stateValue = (long)playerState;
-        if (stateValue == 'kPSP') { // playing
-            state = @"playing";
-        } else if (stateValue == 'kPSp') { // paused
-            state = @"paused";
-        } else {
-            return nil;
+// Split a comma-separated priority list into a C array of bundle ids.
+// Returns the count. Up to PRIORITY_MAX entries are kept; longer inputs
+// are silently truncated.
+NSUInteger parsePriorityList(const char *raw, NSString **out) {
+    if (!raw || !*raw || !out)
+        return 0;
+    NSString *list = [[NSString stringWithUTF8String:raw]
+        stringByReplacingOccurrencesOfString:@"," withString:@" "];
+    NSArray *parts = [list componentsSeparatedByString:@" "];
+    NSUInteger n = 0;
+    for (NSString *p in parts) {
+        NSString *trimmed = [p stringByTrimmingCharactersInSet:
+            [NSCharacterSet whitespaceCharacterSet]];
+        if ([trimmed length] == 0)
+            continue;
+        NSString *bid = bundleIdForName(trimmed);
+        if (!bid)
+            continue;
+        // Avoid duplicates so a single app doesn't get queried twice.
+        BOOL duplicate = NO;
+        for (NSUInteger i = 0; i < n; i++) {
+            if ([out[i] isEqualToString:bid]) { duplicate = YES; break; }
         }
-
-        // Get current track
-        id track = [music performSelector:@selector(currentTrack)];
-        if (!track)
-            return nil;
-
-        NSString *artist = [track performSelector:@selector(artist)];
-        NSString *title = [track performSelector:@selector(name)];
-        NSString *album = [track performSelector:@selector(album)];
-
-        if (!title || [title length] == 0)
-            return nil;
-
-        return @{
-            @"state" : state,
-            @"artist" : sanitize(artist) ?: @"",
-            @"title" : sanitize(title) ?: @"",
-            @"album" : sanitize(album) ?: @"",
-            @"app" : @"Music"
-        };
-    } @catch (NSException *e) {
-        return nil;
+        if (duplicate)
+            continue;
+        if (n >= PRIORITY_MAX)
+            break;
+        out[n++] = bid;
     }
+    return n;
 }
 
 int main(int argc, const char *argv[]) {
     @autoreleasepool {
+        // Parse arguments. Currently only -p <priority-list> is supported.
+        NSString *priority[PRIORITY_MAX];
+        for (int i = 0; i < PRIORITY_MAX; i++) priority[i] = nil;
+        NSUInteger priorityCount = 0;
+
+        for (int i = 1; i < argc; i++) {
+            if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
+                priorityCount = parsePriorityList(argv[i + 1], priority);
+                i++;
+            }
+            // Unknown args are silently ignored for forward compatibility.
+        }
+
         NSDictionary *info = nil;
 
-        // Try Spotify first (more commonly used)
-        info = getSpotifyInfo();
-
-        // Try Music if Spotify didn't return anything
-        if (!info) {
-            info = getMusicInfo();
+        // Try the user-configured priority list first.
+        for (NSUInteger i = 0; i < priorityCount && !info; i++) {
+            info = getInfoForBundleId(priority[i]);
         }
+
+        // Default fallback order: Spotify then Music.
+        if (!info) info = getSpotifyInfo();
+        if (!info) info = getMusicInfo();
 
         // Nothing playing
         if (!info) {

--- a/src/native/macos/powerkit-nowplaying.m
+++ b/src/native/macos/powerkit-nowplaying.m
@@ -62,11 +62,15 @@ BOOL isAppRunning(NSString *bundleId) {
 // Map a friendly app name to its bundle identifier. Returns nil if unknown.
 NSString *bundleIdForName(NSString *name) {
     NSString *low = [name lowercaseString];
-    if ([low isEqualToString:@"spotify"]) return @"com.spotify.client";
-    if ([low isEqualToString:@"music"] || [low isEqualToString:@"apple music"]) return @"com.apple.Music";
-    if ([low isEqualToString:@"itunes"]) return @"com.apple.iTunes";
+    if ([low isEqualToString:@"spotify"])
+        return @"com.spotify.client";
+    if ([low isEqualToString:@"music"] || [low isEqualToString:@"apple music"])
+        return @"com.apple.Music";
+    if ([low isEqualToString:@"itunes"])
+        return @"com.apple.iTunes";
     // Allow callers to pass the raw bundle id too.
-    if ([low hasPrefix:@"com."]) return name;
+    if ([low hasPrefix:@"com."])
+        return name;
     return nil;
 }
 
@@ -149,13 +153,11 @@ NSDictionary *getMusicInfo(void) {
 NSUInteger parsePriorityList(const char *raw, NSString **out) {
     if (!raw || !*raw || !out)
         return 0;
-    NSString *list = [[NSString stringWithUTF8String:raw]
-        stringByReplacingOccurrencesOfString:@"," withString:@" "];
+    NSString *list = [[NSString stringWithUTF8String:raw] stringByReplacingOccurrencesOfString:@"," withString:@" "];
     NSArray *parts = [list componentsSeparatedByString:@" "];
     NSUInteger n = 0;
     for (NSString *p in parts) {
-        NSString *trimmed = [p stringByTrimmingCharactersInSet:
-            [NSCharacterSet whitespaceCharacterSet]];
+        NSString *trimmed = [p stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         if ([trimmed length] == 0)
             continue;
         NSString *bid = bundleIdForName(trimmed);
@@ -164,7 +166,10 @@ NSUInteger parsePriorityList(const char *raw, NSString **out) {
         // Avoid duplicates so a single app doesn't get queried twice.
         BOOL duplicate = NO;
         for (NSUInteger i = 0; i < n; i++) {
-            if ([out[i] isEqualToString:bid]) { duplicate = YES; break; }
+            if ([out[i] isEqualToString:bid]) {
+                duplicate = YES;
+                break;
+            }
         }
         if (duplicate)
             continue;
@@ -179,7 +184,8 @@ int main(int argc, const char *argv[]) {
     @autoreleasepool {
         // Parse arguments. Currently only -p <priority-list> is supported.
         NSString *priority[PRIORITY_MAX];
-        for (int i = 0; i < PRIORITY_MAX; i++) priority[i] = nil;
+        for (int i = 0; i < PRIORITY_MAX; i++)
+            priority[i] = nil;
         NSUInteger priorityCount = 0;
 
         for (int i = 1; i < argc; i++) {
@@ -198,8 +204,10 @@ int main(int argc, const char *argv[]) {
         }
 
         // Default fallback order: Spotify then Music.
-        if (!info) info = getSpotifyInfo();
-        if (!info) info = getMusicInfo();
+        if (!info)
+            info = getSpotifyInfo();
+        if (!info)
+            info = getMusicInfo();
 
         // Nothing playing
         if (!info) {

--- a/src/plugins/aiquotas.sh
+++ b/src/plugins/aiquotas.sh
@@ -48,6 +48,7 @@ declare -gA AIQUOTAS_LABELS=(
     [deepseek]="DeepSeek"
     [minimax]="MiniMax"
     [zai]="zai"
+    [kimicode]="Kimi"
 )
 
 # Default URLs per provider endpoint. URL can be overridden via plugin options.
@@ -62,6 +63,7 @@ declare -gA AIQUOTAS_DEFAULT_URLS=(
     [deepseek_balance]="https://api.deepseek.com/user/balance"
     [minimax_usage]="https://api.minimax.io/v1/token_plan/remains"
     [zai_quota]="https://api.z.ai/api/monitor/usage/quota/limit"
+    [kimicode_usage]="https://api.kimi.com/coding/v1/usages"
 )
 
 # =============================================================================
@@ -131,6 +133,7 @@ _aiquotas_load_all_providers() {
     _aiquotas_load_provider deepseek
     _aiquotas_load_provider minimax
     _aiquotas_load_provider zai
+    _aiquotas_load_provider kimicode
 }
 
 # =============================================================================
@@ -204,6 +207,9 @@ plugin_declare_options() {
     # Z.ai (Zhipu GLM Coding Plan)
     declare_option "zai_quota_url" "string" "${AIQUOTAS_DEFAULT_URLS[zai_quota]}" "Z.ai quota/limit endpoint (Coding Plan 5h quota)"
 
+    # Kimi Code (Moonshot AI)
+    declare_option "kimicode_usage_url" "string" "${AIQUOTAS_DEFAULT_URLS[kimicode_usage]}" "Kimi Code usage/quota endpoint"
+
     declare_option "icon" "icon" $'\uEE9C' "Plugin icon (brain)"
     declare_option "cache_ttl" "number" "300" "Cache duration in seconds"
 }
@@ -243,6 +249,7 @@ _aiquotas_collect_provider() {
     deepseek) _aiquotas_collect_deepseek 2>/dev/null ;;
     minimax) _aiquotas_collect_minimax 2>/dev/null ;;
     zai) _aiquotas_collect_zai 2>/dev/null ;;
+    kimicode) _aiquotas_collect_kimicode 2>/dev/null ;;
     *) return 64 ;;
     esac
 }
@@ -270,7 +277,7 @@ plugin_collect() {
         [[ -n "$provider" ]] || continue
 
         case "$provider" in
-        anthropic | openai | deepseek | minimax | zai)
+        anthropic | openai | deepseek | minimax | zai | kimicode)
             # Unified dispatch: every adapter owns its own HTTP+normalization
             # and returns a canonical metrics document on stdout (or empty
             # on hard transport failure). See _aiquotas_collect_provider.

--- a/src/plugins/aiquotas/_http.sh
+++ b/src/plugins/aiquotas/_http.sh
@@ -47,6 +47,49 @@ _aiquotas_http_get_meta() {
     printf '%s' "$body"
 }
 
+# Credential-safe HTTP GET: header_name + header_value are routed to curl
+# via stdin (so the secret never appears in process argv). All other args
+# pass through argv as usual. Use this whenever an API key, cookie or
+# bearer token would otherwise be appended via -H "..." in argv.
+# Usage: _aiquotas_http_get_meta_authed "url" "timeout" "Header-Name" "Header-Value" [extra_argv...]
+_aiquotas_http_get_meta_authed() {
+    local url="$1"
+    local timeout="${2:-5}"
+    local header_name="$3"
+    local header_value="$4"
+    shift 4
+    local extra_args=("$@")
+    local body rc
+    body=$(printf 'header = "%s: %s"\n' "$header_name" "$header_value" | curl -s \
+        --config - \
+        --connect-timeout "$timeout" \
+        --max-time "$((timeout * 2))" \
+        "${extra_args[@]}" \
+        "$url" 2>/dev/null)
+    rc=$?
+    if ((rc != 0)); then
+        printf ''
+        return "$rc"
+    fi
+    printf '%s' "$body"
+}
+
+# Same as _aiquotas_http_get_meta_authed but for the strict (`-sf`) seam.
+_aiquotas_http_get_authed() {
+    local url="$1"
+    local timeout="${2:-5}"
+    local header_name="$3"
+    local header_value="$4"
+    shift 4
+    local extra_args=("$@")
+    curl -sf \
+        --connect-timeout "$timeout" \
+        --max-time "$((timeout * 2))" \
+        --config <(printf 'header = "%s: %s"\n' "$header_name" "$header_value") \
+        "${extra_args[@]}" \
+        "$url" 2>/dev/null
+}
+
 # Read the HTTP status the shim served for the most recent call.
 # Falls back to "200" when no shim is active (real curl has no concept of
 # last_status; the adapter contract assumes 2xx on transport success).

--- a/src/plugins/aiquotas/_render.sh
+++ b/src/plugins/aiquotas/_render.sh
@@ -14,6 +14,8 @@ source_guard "aiquotas_render" && return 0
 
 # Compact a numeric value for display (e.g., 1250000 -> 1.2M).
 # Returns the input unchanged when not a non-negative integer.
+# Pure bash: integer divide by 1000/1000000 for the magnitude, then
+# derive the one decimal digit from the remainder.
 _aiquotas_compact_value() {
     local value="$1"
     [[ "$value" =~ ^[0-9]+$ ]] || {
@@ -21,9 +23,17 @@ _aiquotas_compact_value() {
         return
     }
     if ((value >= 1000000)); then
-        awk -v v="$value" 'BEGIN { printf "%.1fM", v / 1000000 }'
+        # Round to nearest 0.1M: (value + 50000) / 1000000.
+        local tenths=$(((value + 50000) / 100000))
+        local millions=$((tenths / 10))
+        local dec=$((tenths % 10))
+        printf '%d.%dM' "$millions" "$dec"
     elif ((value >= 1000)); then
-        awk -v v="$value" 'BEGIN { printf "%.1fK", v / 1000 }'
+        # Round to nearest 0.1K: (value + 50) / 1000.
+        local tenths=$(((value + 50) / 100))
+        local thousands=$((tenths / 10))
+        local dec=$((tenths % 10))
+        printf '%d.%dK' "$thousands" "$dec"
     else
         printf '%s' "$value"
     fi
@@ -32,6 +42,7 @@ _aiquotas_compact_value() {
 # Calculate rounded usage/available percentages for quota-shaped records.
 # A zero-sized, unused quota is treated as fully available so the renderer can
 # still explain API responses such as value=0, limit=0, remaining=0.
+# Pure bash: integer math with manual decimal handling.
 _aiquotas_quota_percentages() {
     local value="$1"
     local limit="$2"
@@ -41,22 +52,35 @@ _aiquotas_quota_percentages() {
     [[ "$limit" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
 
     if ! [[ "$remaining" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
-        remaining=$(awk -v v="$value" -v l="$limit" 'BEGIN { print l - v }')
+        # limit - value: trim decimals to integer for the bash subtraction.
+        local lim_int val_int
+        lim_int="${limit%%.*}"
+        val_int="${value%%.*}"
+        remaining=$((lim_int - val_int))
     fi
 
-    awk -v v="$value" -v l="$limit" -v r="$remaining" '
-        BEGIN {
-            if (l == 0) {
-                if (v == 0) {
-                    print "0 100"
-                } else {
-                    print "100 0"
-                }
-                exit
-            }
-            printf "%.0f %.0f\n", (v / l) * 100, (r / l) * 100
-        }
-    '
+    # Zero-limit edge cases match the original awk logic.
+    local lim_int="${limit%%.*}"
+    local val_int="${value%%.*}"
+    local rem_int="${remaining%%.*}"
+    lim_int="${lim_int:-0}"
+    val_int="${val_int:-0}"
+    rem_int="${rem_int:-0}"
+
+    if ((lim_int == 0)); then
+        if ((val_int == 0)); then
+            printf '0 100'
+        else
+            printf '100 0'
+        fi
+        return
+    fi
+
+    # Rounded percentage = round( value * 100 / limit ).
+    # Use bash arithmetic: (val * 100 + lim/2) / lim  for rounding to nearest int.
+    local usage_pct=$(((val_int * 100 + lim_int / 2) / lim_int))
+    local available_pct=$(((rem_int * 100 + lim_int / 2) / lim_int))
+    printf '%d %d' "$usage_pct" "$available_pct"
 }
 
 _aiquotas_render_label() {
@@ -69,7 +93,8 @@ _aiquotas_render_label() {
         openai) printf 'OAI' ;;
         deepseek) printf 'DS' ;;
         minimax) printf 'MM' ;;
-        zai) printf 'zai' ;;
+        zai) printf 'ZA' ;;
+        kimicode) printf 'KM' ;;
         *) printf '%s' "$provider" ;;
         esac
         return

--- a/src/plugins/aiquotas/_render.sh
+++ b/src/plugins/aiquotas/_render.sh
@@ -93,7 +93,7 @@ _aiquotas_render_label() {
         openai) printf 'OAI' ;;
         deepseek) printf 'DS' ;;
         minimax) printf 'MM' ;;
-        zai) printf 'ZA' ;;
+        zai) printf 'zai' ;;
         kimicode) printf 'KM' ;;
         *) printf '%s' "$provider" ;;
         esac

--- a/src/plugins/aiquotas/anthropic.sh
+++ b/src/plugins/aiquotas/anthropic.sh
@@ -99,9 +99,9 @@ _aiquotas_collect_anthropic() {
         [[ -n "$cursor" ]] && page_url="${page_url}&page=${cursor}"
 
         local body status
-        body=$(_aiquotas_http_get_meta \
+        body=$(_aiquotas_http_get_meta_authed \
             "$page_url" "$timeout" \
-            -H "x-api-key: $key" \
+            "x-api-key" "$key" \
             -H "anthropic-version: 2023-06-01" \
             -H "Accept: application/json") || {
             usage_status="unavailable"
@@ -171,9 +171,9 @@ _aiquotas_collect_anthropic() {
     local cost_error=""
     local cost_records_json='[]'
     local cost_body
-    cost_body=$(_aiquotas_http_get_meta \
+    cost_body=$(_aiquotas_http_get_meta_authed \
         "$cost_url" "$timeout" \
-        -H "x-api-key: $key" \
+        "x-api-key" "$key" \
         -H "anthropic-version: 2023-06-01" \
         -H "Accept: application/json") || {
         cost_status="unavailable"

--- a/src/plugins/aiquotas/deepseek.sh
+++ b/src/plugins/aiquotas/deepseek.sh
@@ -59,9 +59,9 @@ _aiquotas_collect_deepseek() {
         return 0
     fi
 
-    body=$(_aiquotas_http_get_meta \
+    body=$(_aiquotas_http_get_meta_authed \
         "$url" "$timeout" \
-        -H "Authorization: Bearer $key" \
+        "Authorization" "Bearer $key" \
         -H "Accept: application/json") || {
         jq -nc '
             {schema_version:1, records:[],

--- a/src/plugins/aiquotas/kimicode.sh
+++ b/src/plugins/aiquotas/kimicode.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# aiquotas adapter — kimicode (Kimi Code / Moonshot AI)
+# =============================================================================
+# Companion adapter for the aiquotas plugin. Provides _aiquotas_collect_kimicode
+# which emits a canonical metrics document for the Kimi Code usage/quota.
+#
+# Loaded lazily by _aiquotas_load_provider in the entry point. NEVER source this
+# file directly — go through the loader.
+#
+# Endpoint: GET https://api.kimi.com/coding/v1/usages
+# Auth:     Authorization: Bearer <KIMI_CODE_API_KEY>
+# Shape:    {usage:{limit, remaining, resetTime},
+#            limits:[{window:{duration, timeUnit}, detail:{limit, remaining}}]}
+#           Primary: usage.limit/remaining (weekly window).
+#           Secondary: limits[].detail (5h rolling rate limit).
+#
+# The endpoint is the same one the Kimi Code CLI and web console query for
+# usage tracking.
+# =============================================================================
+
+POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+. "${POWERKIT_ROOT}/src/core/guard.sh"
+source_guard "aiquotas_kimicode" && return 0
+
+# -----------------------------------------------------------------------------
+# Kimi Code adapter
+# -----------------------------------------------------------------------------
+#
+# Reads the Kimi Code usage endpoint and emits one quota record for the weekly
+# window (5h rate limit as a dimension). Treats the data as `official` ONLY
+# when KIMI_CODE_API_KEY is set.
+#
+# Returns the canonical JSON document on stdout. Exits 0 even on partial
+# failure (the document's provider_outcomes entry carries the error); exits
+# non-zero only when jq cannot assemble the envelope at all.
+#
+_aiquotas_collect_kimicode() {
+    local key="${KIMI_CODE_API_KEY:-}"
+
+    if [[ -z "$key" ]]; then
+        jq -nc '
+            {schema_version:1, records:[],
+             provider_outcomes:[{provider:"kimicode",source:"official",
+                                 status:"unconfigured",
+                                 error:"KIMI_CODE_API_KEY not set"}]}
+        '
+        return 0
+    fi
+
+    local url timeout body status
+    url=$(get_option "kimicode_usage_url")
+    timeout=$(get_option "timeout")
+    timeout="${timeout:-5}"
+
+    if [[ -z "$url" ]]; then
+        jq -nc '
+            {schema_version:1, records:[],
+             provider_outcomes:[{provider:"kimicode",source:"official",
+                                 status:"unconfigured",
+                                 error:"kimicode usage URL not configured"}]}
+        '
+        return 0
+    fi
+
+    # Standard GET request. The credential travels via stdin so it never
+    # appears in argv.
+    body=$(_aiquotas_http_get_meta_authed \
+        "$url" "$timeout" \
+        "Authorization" "Bearer $key" \
+        -H "Accept: application/json") || body=""
+    status=$(_aiquotas_last_status)
+
+    if [[ -z "$body" ]]; then
+        jq -nc '
+            {schema_version:1, records:[],
+             provider_outcomes:[{provider:"kimicode",source:"official",
+                                 status:"unavailable",
+                                 error:"quota fetch transport failure"}]}
+        '
+        return 0
+    fi
+
+    if [[ "$status" != 2* ]]; then
+        local canonical_status canonical_error
+        canonical_status=$(_aiquotas_http_status_to_canonical "$status")
+        canonical_error=$(_aiquotas_http_status_error_message "$body" "quota")
+        jq -nc \
+            --arg st "$canonical_status" \
+            --arg er "$canonical_error" \
+            --arg src "official" \
+            '
+            {schema_version:1, records:[],
+             provider_outcomes:[{provider:"kimicode",source:$src,
+                                 status:$st, error:$er}]}
+            '
+        return 0
+    fi
+
+    if ! _aiquotas_metrics_document "kimicode" "$body" 2>/dev/null; then
+        jq -nc '
+            {schema_version:1, records:[],
+             provider_outcomes:[{provider:"kimicode",source:"official",
+                                 status:"malformed",
+                                 error:"quota payload normalization failed"}]}
+        '
+        return 0
+    fi
+}

--- a/src/plugins/aiquotas/minimax.sh
+++ b/src/plugins/aiquotas/minimax.sh
@@ -58,9 +58,9 @@ _aiquotas_collect_minimax() {
         return 0
     fi
 
-    body=$(_aiquotas_http_get_meta \
+    body=$(_aiquotas_http_get_meta_authed \
         "$url" "$timeout" \
-        -H "Authorization: Bearer $key" \
+        "Authorization" "Bearer $key" \
         -H "Accept: application/json") || {
         jq -nc '
             {schema_version:1, records:[],

--- a/src/plugins/aiquotas/openai.sh
+++ b/src/plugins/aiquotas/openai.sh
@@ -104,9 +104,9 @@ _aiquotas_collect_openai_codex() {
     fi
 
     local body status
-    body=$(_aiquotas_http_get_skim \
+    body=$(_aiquotas_http_get_meta_authed \
         "https://chatgpt.com/backend-api/wham/usage" "$timeout" \
-        -H "Authorization: Bearer $access_token" \
+        "Authorization" "Bearer $access_token" \
         -H "User-Agent: tmux-powerkit/1.0" \
         -H "ChatGPT-Account-Id: $account_id") || {
         jq -nc '
@@ -309,9 +309,9 @@ _aiquotas_collect_openai() {
         [[ -n "$cursor" ]] && page_url="${page_url}&page=${cursor}"
 
         local body status
-        body=$(_aiquotas_http_get_skim \
+        body=$(_aiquotas_http_get_meta_authed \
             "$page_url" "$timeout" \
-            -H "Authorization: Bearer $key" \
+            "Authorization" "Bearer $key" \
             -H "Accept: application/json") || {
             usage_status="unavailable"
             usage_error="usage fetch transport failure"
@@ -382,9 +382,9 @@ _aiquotas_collect_openai() {
     local cost_error=""
     local cost_records_json='[]'
     local cost_body
-    cost_body=$(_aiquotas_http_get_skim \
+    cost_body=$(_aiquotas_http_get_meta_authed \
         "$cost_url" "$timeout" \
-        -H "Authorization: Bearer $key" \
+        "Authorization" "Bearer $key" \
         -H "Accept: application/json") || {
         cost_status="unavailable"
         cost_error="cost fetch transport failure"

--- a/src/plugins/aiquotas/xiaomi_mimo.sh
+++ b/src/plugins/aiquotas/xiaomi_mimo.sh
@@ -72,30 +72,43 @@ _aiquotas_collect_xiaomi_mimo() {
     timeout=$(get_option "timeout")
     timeout="${timeout:-5}"
 
-    # Build curl args based on auth method
-    local -a curl_args=()
+    # Route the credential through stdin so it never appears in curl argv.
+    # Pick whichever credential the operator configured (cookie wins over
+    # bearer when both are present), and pass only the safe extra args
+    # to the helper.
+    local auth_header_name="" auth_header_value="" body
     if [[ -n "$cookies" ]]; then
-        # Session cookie authentication
-        curl_args+=(-H "Cookie: $cookies")
+        auth_header_name="Cookie"
+        auth_header_value="$cookies"
     elif [[ -n "$key" ]]; then
-        # Bearer token authentication (for private adapters)
-        curl_args+=(-H "Authorization: Bearer $key")
+        auth_header_name="Authorization"
+        auth_header_value="Bearer $key"
     fi
 
-    body=$(_aiquotas_http_get_meta \
-        "$url" "$timeout" \
-        "${curl_args[@]}" \
-        -H "Accept: application/json" \
-        -H "Content-Type: application/json" \
-        -H "x-timeZone: $(date +%Z 2>/dev/null || echo "UTC")") || {
+    if [[ -n "$auth_header_name" ]]; then
+        body=$(_aiquotas_http_get_meta_authed \
+            "$url" "$timeout" \
+            "$auth_header_name" "$auth_header_value" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "x-timeZone: $(date +%Z 2>/dev/null || echo "UTC")") || {
+            jq -nc '
+                {schema_version:1, records:[],
+                 provider_outcomes:[{provider:"xiaomi_mimo",source:"configured",
+                                     status:"unavailable",
+                                     error:"usage fetch transport failure"}]}
+            '
+            return 0
+        }
+    else
         jq -nc '
             {schema_version:1, records:[],
              provider_outcomes:[{provider:"xiaomi_mimo",source:"configured",
-                                 status:"unavailable",
-                                 error:"usage fetch transport failure"}]}
+                                 status:"unconfigured",
+                                 error:"xiaomi_mimo usage requires cookie or bearer key"}]}
         '
         return 0
-    }
+    fi
 
     status=$(_aiquotas_last_status)
     if [[ "$status" != 2* ]]; then

--- a/src/plugins/aiquotas/zai.sh
+++ b/src/plugins/aiquotas/zai.sh
@@ -68,17 +68,18 @@ _aiquotas_collect_zai() {
 
     # The Z.ai monitor endpoints accept the raw API key (matching the web
     # console). Some keys require the Bearer form, so retry on a 401.
-    body=$(_aiquotas_http_get_meta \
+    # The credential travels via stdin so it never appears in argv.
+    body=$(_aiquotas_http_get_meta_authed \
         "$url" "$timeout" \
-        -H "Authorization: $key" \
+        "Authorization" "$key" \
         -H "Content-Type: application/json" \
         -H "Accept-Language: en-US,en") || body=""
     status=$(_aiquotas_last_status)
 
     if [[ "$status" == "401" ]]; then
-        body=$(_aiquotas_http_get_meta \
+        body=$(_aiquotas_http_get_meta_authed \
             "$url" "$timeout" \
-            -H "Authorization: Bearer $key" \
+            "Authorization" "Bearer $key" \
             -H "Content-Type: application/json" \
             -H "Accept-Language: en-US,en") || body=""
         status=$(_aiquotas_last_status)

--- a/src/plugins/audiodevices.sh
+++ b/src/plugins/audiodevices.sh
@@ -24,9 +24,9 @@ plugin_get_metadata() {
 
 plugin_check_dependencies() {
     if is_macos; then
-        require_cmd "SwitchAudioSource" 1  # Optional
+        require_cmd "SwitchAudioSource" 1 # Optional
     else
-        require_cmd "pactl" 1  # Optional
+        require_cmd "pactl" 1 # Optional
     fi
     return 0
 }
@@ -67,8 +67,14 @@ plugin_get_presence() { printf 'conditional'; }
 plugin_get_state() {
     local show
     show=$(get_option "display_mode")
-    [[ "$show" == "off" ]] && { printf 'inactive'; return; }
-    [[ "$(_get_audio_system)" == "none" ]] && { printf 'inactive'; return; }
+    [[ "$show" == "off" ]] && {
+        printf 'inactive'
+        return
+    }
+    [[ "$(_get_audio_system)" == "none" ]] && {
+        printf 'inactive'
+        return
+    }
     printf 'active'
 }
 plugin_get_health() { printf 'ok'; }
@@ -76,10 +82,10 @@ plugin_get_health() { printf 'ok'; }
 plugin_get_context() {
     local mode=$(get_option "display_mode")
     case "$mode" in
-        input)  printf 'input_only' ;;
-        output) printf 'output_only' ;;
-        both)   printf 'both_devices' ;;
-        *)      printf 'disabled' ;;
+    input) printf 'input_only' ;;
+    output) printf 'output_only' ;;
+    both) printf 'both_devices' ;;
+    *) printf 'disabled' ;;
     esac
 }
 
@@ -106,8 +112,8 @@ _get_audio_input() {
     else
         local src
         src=$(pactl get-default-source 2>/dev/null)
-        [[ -n "$src" ]] && pactl list sources 2>/dev/null | \
-            grep -A 20 "Name: $src" | grep "Description:" | \
+        [[ -n "$src" ]] && pactl list sources 2>/dev/null |
+            grep -A 20 "Name: $src" | grep "Description:" |
             cut -d: -f2- | sed 's/^ *//'
     fi
 }
@@ -118,8 +124,8 @@ _get_audio_output() {
     else
         local sink
         sink=$(pactl get-default-sink 2>/dev/null)
-        [[ -n "$sink" ]] && pactl list sinks 2>/dev/null | \
-            grep -A 20 "Name: $sink" | grep "Description:" | \
+        [[ -n "$sink" ]] && pactl list sinks 2>/dev/null |
+            grep -A 20 "Name: $sink" | grep "Description:" |
             cut -d: -f2- | sed 's/^ *//'
     fi
 }
@@ -128,22 +134,34 @@ plugin_collect() {
     local show input output
     show=$(get_option "display_mode")
 
+    # Invalidate the plugin cache when display_mode changes so the new
+    # mode takes effect on the very next render instead of waiting for
+    # the TTL window. The previous mode is tracked in a side cache key
+    # that lives across the cache TTL.
+    local prev_mode_key="audiodevices:prev_display_mode"
+    local prev_mode
+    prev_mode=$(cache_get "$prev_mode_key" "86400" 2>/dev/null || echo "")
+    if [[ -n "$prev_mode" && "$prev_mode" != "$show" ]]; then
+        cache_clear "plugin_audiodevices"
+    fi
+    cache_set "$prev_mode_key" "$show" "86400" 2>/dev/null || true
+
     # Skip if audio system not available
     [[ "$show" == "off" ]] && return 0
     [[ "$(_get_audio_system)" == "none" ]] && return 0
 
     case "$show" in
-        input|both)
-            input=$(_get_audio_input)
-            plugin_data_set "input" "${input:-Unknown}"
-            ;;
+    input | both)
+        input=$(_get_audio_input)
+        plugin_data_set "input" "${input:-Unknown}"
+        ;;
     esac
 
     case "$show" in
-        output|both)
-            output=$(_get_audio_output)
-            plugin_data_set "output" "${output:-Unknown}"
-            ;;
+    output | both)
+        output=$(_get_audio_output)
+        plugin_data_set "output" "${output:-Unknown}"
+        ;;
     esac
 }
 
@@ -196,4 +214,3 @@ plugin_setup_keybindings() {
     pk_bind_shell "$input_key" "bash '$helper_script' input" "audiodevices:input"
     pk_bind_shell "$output_key" "bash '$helper_script' output" "audiodevices:output"
 }
-

--- a/src/plugins/bitbucket.sh
+++ b/src/plugins/bitbucket.sh
@@ -195,10 +195,12 @@ _bb_api_call() {
     email=$(get_option "email")
     token=$(get_option "token")
 
+    # Credentials travel via curl --config (stdin) rather than as argv
+    # elements, so a process inspection does not see the token.
     if [[ "$bb_type" == "datacenter" ]]; then
-        make_api_call "$url" "bearer" "$token" 5
+        api_fetch_with_bearer "$url" "$token" 5
     else
-        make_api_call "$url" "basic" "${email}:${token}" 5
+        api_fetch_with_basic_config "$url" "$email" "$token" 5
     fi
 }
 

--- a/src/plugins/bitbucket.sh
+++ b/src/plugins/bitbucket.sh
@@ -247,6 +247,7 @@ plugin_collect() {
     IFS=',' read -ra repos <<<"$repos_csv"
 
     local total_issues=0 total_prs=0
+    local attempted=0 failed=0
 
     for repo_spec in "${repos[@]}"; do
         repo_spec=$(trim "$repo_spec")
@@ -256,20 +257,36 @@ plugin_collect() {
         local repo_slug="$(_urlencode "${repo_spec#*/}")"
 
         if [[ "$show_issues" == "on" || "$show_issues" == "true" ]]; then
-            local issues=0
-            issues=$(_count_issues "$workspace" "$repo_slug") || issues=0
-            total_issues=$((total_issues + issues))
+            ((attempted++))
+            local issues
+            if ! issues=$(_count_issues "$workspace" "$repo_slug"); then
+                ((failed++))
+            else
+                total_issues=$((total_issues + issues))
+            fi
         fi
 
         if [[ "$show_prs" == "on" || "$show_prs" == "true" ]]; then
-            local prs=0
-            prs=$(_count_prs "$workspace" "$repo_slug") || prs=0
-            total_prs=$((total_prs + prs))
+            ((attempted++))
+            local prs
+            if ! prs=$(_count_prs "$workspace" "$repo_slug"); then
+                ((failed++))
+            else
+                total_prs=$((total_prs + prs))
+            fi
         fi
     done
 
     plugin_data_set "issues" "$total_issues"
     plugin_data_set "prs" "$total_prs"
+
+    # If every attempted counter failed, refuse to overwrite the prior
+    # cache. The lifecycle will preserve the previous record and mark
+    # the result as stale. A partial failure keeps the partial success
+    # and continues.
+    if ((attempted > 0 && failed == attempted)); then
+        return 1
+    fi
 }
 
 plugin_render() {

--- a/src/plugins/cloudstatus.sh
+++ b/src/plugins/cloudstatus.sh
@@ -42,7 +42,7 @@ plugin_get_metadata() {
 
 plugin_check_dependencies() {
     require_cmd "curl" || return 1
-    require_cmd "jq" 1  # Optional - improves JSON parsing
+    require_cmd "jq" 1 # Optional - improves JSON parsing
     return 0
 }
 
@@ -191,10 +191,10 @@ _parse_azure() {
         local status
         status=$(printf '%s' "$data" | jq -r '.status.health // "good"' 2>/dev/null)
         case "$status" in
-            good|healthy) printf 'operational' ;;
-            advisory|degraded) printf 'minor' ;;
-            critical|unhealthy) printf 'major' ;;
-            *) printf 'operational' ;;
+        good | healthy) printf 'operational' ;;
+        advisory | degraded) printf 'minor' ;;
+        critical | unhealthy) printf 'major' ;;
+        *) printf 'operational' ;;
         esac
         return
     fi
@@ -209,10 +209,10 @@ _parse_slack() {
         local status
         status=$(printf '%s' "$data" | jq -r '.status // "ok"' 2>/dev/null)
         case "$status" in
-            ok|active) printf 'operational' ;;
-            notice) printf 'minor' ;;
-            incident|outage) printf 'major' ;;
-            *) printf 'operational' ;;
+        ok | active) printf 'operational' ;;
+        notice) printf 'minor' ;;
+        incident | outage) printf 'major' ;;
+        *) printf 'operational' ;;
         esac
         return
     fi
@@ -239,40 +239,43 @@ _get_provider_status() {
     [[ -z "$provider_config" ]] && return 1
 
     local _name api_url icon timeout
-    IFS='|' read -r _name api_url icon <<< "$provider_config"
+    IFS='|' read -r _name api_url icon <<<"$provider_config"
     timeout=$(get_option "timeout")
     timeout="${timeout:-5}"
 
     local data
     data=$(safe_curl "$api_url" "$timeout" 2>/dev/null)
-    [[ -z "$data" ]] && { printf 'unknown'; return; }
+    [[ -z "$data" ]] && {
+        printf 'unknown'
+        return
+    }
 
     # Provider-specific parsers
     case "$provider_key" in
-        aws)    _parse_aws "$data" ;;
-        gcp)    _parse_gcp "$data" ;;
-        azure)  _parse_azure "$data" ;;
-        slack)  _parse_slack "$data" ;;
-        heroku) _parse_heroku "$data" ;;
-        *)      _parse_statuspage "$data" ;;
+    aws) _parse_aws "$data" ;;
+    gcp) _parse_gcp "$data" ;;
+    azure) _parse_azure "$data" ;;
+    slack) _parse_slack "$data" ;;
+    heroku) _parse_heroku "$data" ;;
+    *) _parse_statuspage "$data" ;;
     esac
 }
 
 _normalize_status() {
     case "$1" in
-        none|operational|green|ok) printf 'ok' ;;
-        minor|degraded*|yellow)    printf 'warning' ;;
-        major|partial*|critical*)  printf 'error' ;;
-        *)                         printf 'unknown' ;;
+    none | operational | green | ok) printf 'ok' ;;
+    minor | degraded* | yellow) printf 'warning' ;;
+    major | partial* | critical*) printf 'error' ;;
+    *) printf 'unknown' ;;
     esac
 }
 
 _get_status_indicator() {
     local status="$1"
     case "$status" in
-        warning) printf '!' ;;
-        error)   printf '!!' ;;
-        *)       printf '' ;;
+    warning) printf '!' ;;
+    error) printf '!!' ;;
+    *) printf '' ;;
     esac
 }
 
@@ -293,9 +296,9 @@ plugin_get_health() {
     local severity
     severity=$(plugin_data_get "severity")
     case "$severity" in
-        error) printf 'error' ;;
-        warning) printf 'warning' ;;
-        *) printf 'ok' ;;
+    error) printf 'error' ;;
+    warning) printf 'warning' ;;
+    *) printf 'ok' ;;
     esac
 }
 
@@ -303,9 +306,9 @@ plugin_get_context() {
     local severity
     severity=$(plugin_data_get "severity")
     case "$severity" in
-        error) printf 'incident' ;;
-        warning) printf 'degraded' ;;
-        *) printf 'operational' ;;
+    error) printf 'incident' ;;
+    warning) printf 'degraded' ;;
+    *) printf 'operational' ;;
     esac
 }
 
@@ -314,9 +317,9 @@ plugin_get_icon() {
     local severity
     severity=$(plugin_data_get "severity")
     case "$severity" in
-        error)   get_option "icon_error" ;;
-        warning) get_option "icon_warning" ;;
-        *)       get_option "icon" ;;
+    error) get_option "icon_error" ;;
+    warning) get_option "icon_warning" ;;
+    *) get_option "icon" ;;
     esac
 }
 
@@ -336,24 +339,46 @@ plugin_collect() {
 
     local output_parts=()
     local has_error=false has_warning=false has_issues=false
+    local attempted=0 unknown_count=0
     local provider raw_status normalized indicator icon
 
-    IFS=',' read -ra provider_list <<< "$providers"
+    IFS=',' read -ra provider_list <<<"$providers"
 
     for provider in "${provider_list[@]}"; do
         provider=$(trim "$provider")
         [[ -z "$provider" || -z "${CLOUD_PROVIDERS[$provider]}" ]] && continue
 
-        IFS='|' read -r _ _ icon <<< "${CLOUD_PROVIDERS[$provider]}"
+        IFS='|' read -r _ _ icon <<<"${CLOUD_PROVIDERS[$provider]}"
+        ((attempted++))
         raw_status=$(_get_provider_status "$provider")
         normalized=$(_normalize_status "$raw_status")
+
+        # 'unknown' is the result when the provider endpoint is
+        # unreachable, returned malformed JSON, or its schema drifted.
+        # Previously the plugin would silently treat this as operational,
+        # which is unsafe. We now surface it explicitly and fail collection
+        # when every requested provider is unknown so the lifecycle can
+        # preserve the prior cache as stale.
+        if [[ "$normalized" == "unknown" ]]; then
+            ((unknown_count++))
+            # Still render a question-mark indicator so the user can see
+            # which providers could not be contacted.
+            output_parts+=("${icon}?")
+            continue
+        fi
 
         # Skip OK if issues_only
         [[ "$issues_only" == "true" && "$normalized" == "ok" ]] && continue
 
         # Track severity
-        [[ "$normalized" == "error" ]] && { has_error=true; has_issues=true; }
-        [[ "$normalized" == "warning" ]] && { has_warning=true; has_issues=true; }
+        [[ "$normalized" == "error" ]] && {
+            has_error=true
+            has_issues=true
+        }
+        [[ "$normalized" == "warning" ]] && {
+            has_warning=true
+            has_issues=true
+        }
 
         # Add indicator for individual severity
         indicator=$(_get_status_indicator "$normalized")
@@ -364,10 +389,21 @@ plugin_collect() {
     local severity="ok"
     [[ "$has_warning" == "true" ]] && severity="warning"
     [[ "$has_error" == "true" ]] && severity="error"
+    # If every provider returned unknown, treat as error so the renderer
+    # uses the error color and the lifecycle marks the cache as stale.
+    if ((attempted > 0 && unknown_count == attempted)); then
+        severity="error"
+    fi
 
     plugin_data_set "severity" "$severity"
-    plugin_data_set "has_issues" "$([[ "$has_issues" == "true" ]] && echo "1" || echo "0")"
+    plugin_data_set "has_issues" "$([[ "$has_issues" == "true" || "$unknown_count" -gt 0 ]] && echo "1" || echo "0")"
     plugin_data_set "output" "$(join_with_separator ' ' "${output_parts[@]}")"
+
+    # Refuse to overwrite the prior cache if every requested provider
+    # was unreachable or returned a malformed body.
+    if ((attempted > 0 && unknown_count == attempted)); then
+        return 1
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/cpu.sh
+++ b/src/plugins/cpu.sh
@@ -104,8 +104,8 @@ _get_cpu_linux() {
         total=$((total + v))
     done
 
-    # Get current timestamp (using bash built-in if available, or date)
-    local current_time="${EPOCHSECONDS:-$(date +%s)}"
+    # Get current timestamp (Bash 5.1+ builtin; no fallback needed)
+    local current_time="${EPOCHSECONDS}"
 
     # Get previous snapshot from cache (24h TTL - only invalid on reboot)
     local prev_idle prev_total prev_timestamp

--- a/src/plugins/crypto.sh
+++ b/src/plugins/crypto.sh
@@ -177,7 +177,15 @@ plugin_collect() {
 
     local response
     response=$(_fetch_coingecko "$coins")
-    [[ -z "$response" ]] && return 0
+    [[ -z "$response" ]] && return 1
+
+    # Validate JSON before parsing. A 200 with a body that is not JSON
+    # (e.g. HTML error page from a CDN) used to fall through to jq which
+    # then returned empty for every coin, silently succeeding with zero
+    # data and overwriting the prior cache.
+    if ! api_validate_json "$response"; then
+        return 1
+    fi
 
     local currency currency_lower show_change
     currency=$(get_option "currency")
@@ -185,6 +193,7 @@ plugin_collect() {
     show_change=$(get_option "show_change")
 
     local prices_data=""
+    local attempted=0 parsed=0
     IFS=',' read -ra coin_list <<<"$coins"
 
     for coin in "${coin_list[@]}"; do
@@ -193,6 +202,7 @@ plugin_collect() {
 
         local coin_id=$(_get_coin_id "$coin")
         local price change=""
+        ((attempted++))
 
         # Extract price from JSON
         price=$(echo "$response" | jq -r ".\"$coin_id\".\"$currency_lower\" // empty" 2>/dev/null)
@@ -205,8 +215,15 @@ plugin_collect() {
         # Store: SYMBOL:PRICE:CHANGE
         [[ -n "$prices_data" ]] && prices_data+="|"
         prices_data+="${coin}:${price}:${change}"
+        ((parsed++))
     done
 
+    # When no requested coin produced a price, do not write the empty
+    # result. Returning nonzero tells the lifecycle to keep the prior
+    # cache and mark it stale.
+    if ((attempted > 0 && parsed == 0)); then
+        return 1
+    fi
     [[ -n "$prices_data" ]] && plugin_data_set "prices" "$prices_data"
 
     # Build formatted render output

--- a/src/plugins/externalip.sh
+++ b/src/plugins/externalip.sh
@@ -68,6 +68,13 @@ plugin_get_icon() { get_option "icon"; }
 plugin_collect() {
     local ip
     ip=$(safe_curl "https://api.ipify.org" 3)
+    # ipify returns the bare IP, but a transport error or a captive
+    # portal redirect can produce arbitrary text. Validate before
+    # accepting; refuse to overwrite the prior cache otherwise so the
+    # lifecycle can keep the previous record and mark it stale.
+    if ! api_validate_ip "$ip"; then
+        return 1
+    fi
     plugin_data_set "ip" "$ip"
 }
 
@@ -75,4 +82,3 @@ plugin_render() {
     local ip=$(plugin_data_get "ip")
     [[ -n "$ip" ]] && printf '%s' "$ip" || printf 'N/A'
 }
-

--- a/src/plugins/github.sh
+++ b/src/plugins/github.sh
@@ -213,7 +213,10 @@ _make_github_api_call() {
     local url="$1"
     local token=$(_get_token)
 
-    make_api_call "$url" "github" "$token" 5
+    # The token is passed via curl --config (stdin) so it never
+    # appears in process argv. The GitHub API accepts the same
+    # Authorization header that make_api_call was sending.
+    api_fetch_with_token_header "$url" "Authorization" "token ${token}" 5
 }
 
 _get_api_error_message() {
@@ -366,6 +369,7 @@ _get_github_info() {
 
     local total_issues=0 total_prs=0
     local api_error=0
+    local attempted=0 failed=0
 
     for repo_spec in "${repos[@]}"; do
         repo_spec=$(trim "$repo_spec")
@@ -377,24 +381,39 @@ _get_github_info() {
         local issues=0 prs=0
 
         if [[ "$(get_option "show_issues")" == "true" ]]; then
+            ((attempted++))
             if ! issues=$(_count_issues "$owner" "$repo" "$filter_user"); then
                 api_error=1
+                ((failed++))
                 issues=0
+            else
+                total_issues=$((total_issues + issues))
             fi
         fi
 
         if [[ "$(get_option "show_prs")" == "true" ]]; then
+            ((attempted++))
             if ! prs=$(_count_prs "$owner" "$repo" "$filter_user"); then
                 api_error=1
+                ((failed++))
                 prs=0
+            else
+                total_prs=$((total_prs + prs))
             fi
         fi
-
-        total_issues=$((total_issues + issues))
-        total_prs=$((total_prs + prs))
     done
 
-    echo "$total_issues $total_prs $api_error"
+    # Surface a canonical outcome so consumers can distinguish
+    # unauthorized / rate_limited / transport errors instead of seeing
+    # a single generic api_error flag.
+    local outcome="success"
+    if ((attempted > 0 && failed == attempted)); then
+        outcome="transport_error"
+    elif ((api_error > 0)); then
+        outcome="partial_failure"
+    fi
+
+    echo "$total_issues $total_prs $api_error $outcome"
 }
 
 plugin_collect() {
@@ -410,12 +429,13 @@ plugin_collect() {
     fi
 
     local result=$(_get_github_info)
-    local issues prs api_error
-    read -r issues prs api_error <<<"$result"
+    local issues prs api_error outcome
+    read -r issues prs api_error outcome <<<"$result"
 
     issues="${issues:-0}"
     prs="${prs:-0}"
     api_error="${api_error:-0}"
+    outcome="${outcome:-success}"
 
     local total=$((issues + prs))
 
@@ -423,6 +443,11 @@ plugin_collect() {
     plugin_data_set "prs" "$prs"
     plugin_data_set "total" "$total"
     plugin_data_set "api_error" "$api_error"
+    plugin_data_set "api_outcome" "$outcome"
+
+    # If every requested counter failed, refuse to overwrite the prior
+    # cache so the lifecycle can mark it stale.
+    [[ "$outcome" == "transport_error" ]] && return 1
 }
 
 plugin_render() {

--- a/src/plugins/github.sh
+++ b/src/plugins/github.sh
@@ -176,16 +176,15 @@ plugin_get_context() {
         return
     fi
 
-    local api_error=$(plugin_data_get "api_error")
+    printf -v api_error '%s' "$(plugin_data_get "api_error")"
     [[ "$api_error" == "1" ]] && {
         printf 'api_error'
         return
     }
 
-    local total=$(plugin_data_get "total")
-    local issues=$(plugin_data_get "issues")
-    local prs=$(plugin_data_get "prs")
-
+    printf -v total '%s' "$(plugin_data_get "total")"
+    printf -v issues '%s' "$(plugin_data_get "issues")"
+    printf -v prs '%s' "$(plugin_data_get "prs")"
     total="${total:-0}"
     issues="${issues:-0}"
     prs="${prs:-0}"
@@ -211,8 +210,7 @@ plugin_get_icon() { get_option "icon"; }
 
 _make_github_api_call() {
     local url="$1"
-    local token=$(_get_token)
-
+    printf -v token '%s' "$(_get_token)"
     # The token is passed via curl --config (stdin) so it never
     # appears in process argv. The GitHub API accepts the same
     # Authorization header that make_api_call was sending.
@@ -228,7 +226,7 @@ _is_valid_api_response() {
     local response="$1"
     [[ -z "$response" ]] && return 1
 
-    local error_msg=$(_get_api_error_message "$response")
+    printf -v error_msg '%s' "$(_get_api_error_message "$response")"
     [[ -n "$error_msg" ]] && return 1
 
     return 0
@@ -244,13 +242,12 @@ _count_issues() {
     [[ -n "$filter_user" ]] && query="${query}+author:${filter_user}"
 
     local url="$GITHUB_API/search/issues?q=${query}&per_page=1"
-    local response=$(_make_github_api_call "$url")
-
+    printf -v response '%s' "$(_make_github_api_call "$url")"
     # Validate response using api_validate_response
     api_validate_response "$response" || return 1
 
     if has_cmd jq; then
-        local error_msg=$(echo "$response" | jq -r '.message // empty' 2>/dev/null)
+        printf -v error_msg '%s' "$(echo "$response" | jq -r '.message // empty' 2>/dev/null)"
         [[ -n "$error_msg" ]] && return 1
         echo "$response" | jq -r '.total_count // 0' 2>/dev/null
     else
@@ -269,13 +266,12 @@ _count_prs() {
     [[ -n "$filter_user" ]] && query="${query}+author:${filter_user}"
 
     local url="$GITHUB_API/search/issues?q=${query}&per_page=1"
-    local response=$(_make_github_api_call "$url")
-
+    printf -v response '%s' "$(_make_github_api_call "$url")"
     # Validate response using api_validate_response
     api_validate_response "$response" || return 1
 
     if has_cmd jq; then
-        local error_msg=$(echo "$response" | jq -r '.message // empty' 2>/dev/null)
+        printf -v error_msg '%s' "$(echo "$response" | jq -r '.message // empty' 2>/dev/null)"
         [[ -n "$error_msg" ]] && return 1
         echo "$response" | jq -r '.total_count // 0' 2>/dev/null
     else
@@ -285,9 +281,8 @@ _count_prs() {
 
 # Use gh CLI if available
 _fetch_via_gh_cli() {
-    local show_issues=$(get_option "show_issues")
-    local show_prs=$(get_option "show_prs")
-
+    printf -v show_issues '%s' "$(get_option "show_issues")"
+    printf -v show_prs '%s' "$(get_option "show_prs")"
     local issues=0 prs=0
 
     # Check if gh has a default repo set, if not use search API
@@ -321,13 +316,12 @@ _format_repo_status() {
     local issues="$1"
     local prs="$2"
 
-    local show_issues=$(get_option "show_issues")
-    local show_prs=$(get_option "show_prs")
-    local format=$(get_option "format")
-    local separator=$(get_option "separator")
-    local icon_issue=$(get_option "icon_issue")
-    local icon_pr=$(get_option "icon_pr")
-
+    printf -v show_issues '%s' "$(get_option "show_issues")"
+    printf -v show_prs '%s' "$(get_option "show_prs")"
+    printf -v format '%s' "$(get_option "format")"
+    printf -v separator '%s' "$(get_option "separator")"
+    printf -v icon_issue '%s' "$(get_option "icon_issue")"
+    printf -v icon_pr '%s' "$(get_option "icon_pr")"
     local parts=()
 
     if [[ "$show_issues" == "true" && "$issues" -gt 0 ]]; then
@@ -350,12 +344,11 @@ _format_repo_status() {
 }
 
 _get_github_info() {
-    local repos_csv=$(get_option "repos")
-    local filter_user=$(get_option "filter_user")
-
+    printf -v repos_csv '%s' "$(get_option "repos")"
+    printf -v filter_user '%s' "$(get_option "filter_user")"
     # If no repos configured, try gh CLI for user's repos
     if [[ -z "$repos_csv" ]] && has_cmd gh; then
-        local result=$(_fetch_via_gh_cli)
+        printf -v result '%s' "$(_fetch_via_gh_cli)"
         echo "$result"
         return 0
     fi
@@ -428,7 +421,7 @@ plugin_collect() {
         return 0
     fi
 
-    local result=$(_get_github_info)
+    printf -v result '%s' "$(_get_github_info)"
     local issues prs api_error outcome
     read -r issues prs api_error outcome <<<"$result"
 

--- a/src/plugins/github.sh
+++ b/src/plugins/github.sh
@@ -89,7 +89,7 @@ _verify_token() {
     [[ -z "$token" ]] && return 1
 
     local result
-    result=$(make_api_call "${GITHUB_API}/user" "github" "$token" 5) || return 1
+    result=$(api_fetch_with_token_header "${GITHUB_API}/user" "Authorization" "token ${token}" 5) || return 1
     return 0
 }
 

--- a/src/plugins/gitlab.sh
+++ b/src/plugins/gitlab.sh
@@ -69,14 +69,14 @@ _is_authenticated() {
         glab auth status &>/dev/null && return 0
     fi
     # Check for token option or env vars
-    local token=$(get_option "token")
+    printf -v token '%s' "$(get_option "token")"
     [[ -n "$token" ]] && return 0
     [[ -n "${GITLAB_TOKEN:-}" || -n "${GITLAB_PRIVATE_TOKEN:-}" ]] && return 0
     return 1
 }
 
 _has_repos_configured() {
-    local repos=$(get_option "repos")
+    printf -v repos '%s' "$(get_option "repos")"
     [[ -n "$repos" ]] && return 0
     # glab CLI can work without explicit repos
     has_cmd "glab" && return 0
@@ -84,7 +84,7 @@ _has_repos_configured() {
 }
 
 _get_token() {
-    local token=$(get_option "token")
+    printf -v token '%s' "$(get_option "token")"
     [[ -n "$token" ]] && {
         printf '%s' "$token"
         return 0
@@ -109,9 +109,8 @@ plugin_get_state() {
         printf 'degraded'
         return
     fi
-    local total=$(plugin_data_get "total")
-    local api_error=$(plugin_data_get "api_error")
-
+    printf -v total '%s' "$(plugin_data_get "total")"
+    printf -v api_error '%s' "$(plugin_data_get "api_error")"
     if [[ "$api_error" == "1" ]]; then
         printf 'degraded'
     elif [[ "${total:-0}" -gt 0 ]]; then
@@ -127,17 +126,16 @@ plugin_get_health() {
         return
     fi
 
-    local api_error=$(plugin_data_get "api_error")
+    printf -v api_error '%s' "$(plugin_data_get "api_error")"
     [[ "$api_error" == "1" ]] && {
         printf 'error'
         return
     }
 
-    local issues=$(plugin_data_get "issues")
-    local mrs=$(plugin_data_get "mrs")
-    local warning_threshold_issues=$(get_option "warning_threshold_issues")
-    local warning_threshold_mrs=$(get_option "warning_threshold_mrs")
-
+    printf -v issues '%s' "$(plugin_data_get "issues")"
+    printf -v mrs '%s' "$(plugin_data_get "mrs")"
+    printf -v warning_threshold_issues '%s' "$(get_option "warning_threshold_issues")"
+    printf -v warning_threshold_mrs '%s' "$(get_option "warning_threshold_mrs")"
     if [[ "${issues:-0}" -ge "$warning_threshold_issues" || "${mrs:-0}" -ge "$warning_threshold_mrs" ]]; then
         printf 'warning'
     else
@@ -151,16 +149,15 @@ plugin_get_context() {
         return
     fi
 
-    local api_error=$(plugin_data_get "api_error")
+    printf -v api_error '%s' "$(plugin_data_get "api_error")"
     [[ "$api_error" == "1" ]] && {
         printf 'api_error'
         return
     }
 
-    local total=$(plugin_data_get "total")
-    local issues=$(plugin_data_get "issues")
-    local mrs=$(plugin_data_get "mrs")
-
+    printf -v total '%s' "$(plugin_data_get "total")"
+    printf -v issues '%s' "$(plugin_data_get "issues")"
+    printf -v mrs '%s' "$(plugin_data_get "mrs")"
     total="${total:-0}"
     issues="${issues:-0}"
     mrs="${mrs:-0}"
@@ -207,8 +204,7 @@ _url_encode() {
 
 _make_gitlab_api_call() {
     local url="$1"
-    local token=$(_get_token)
-
+    printf -v token '%s' "$(_get_token)"
     # PRIVATE-TOKEN is passed via curl --config (stdin) so it never
     # appears in process argv. The body returned here is the same
     # JSON shape as make_api_call would have given.
@@ -217,8 +213,7 @@ _make_gitlab_api_call() {
 
 _make_gitlab_head_call() {
     local url="$1"
-    local token=$(_get_token)
-
+    printf -v token '%s' "$(_get_token)"
     # Same credential-safe transport for HEAD requests. The header is
     # forwarded via stdin; only the URL is in argv.
     printf 'header = "PRIVATE-TOKEN: %s"\nheader = "X-Head-Only: 1"\nrequest = "HEAD"\n' "$token" |
@@ -227,12 +222,10 @@ _make_gitlab_head_call() {
 
 _count_issues() {
     local project_encoded="$1"
-    local gitlab_url=$(get_option "url")
-
+    printf -v gitlab_url '%s' "$(get_option "url")"
     # Use issues_statistics endpoint - more efficient than listing
     local url="${gitlab_url}/api/v4/projects/${project_encoded}/issues_statistics?scope=all"
-    local response=$(_make_gitlab_api_call "$url")
-
+    printf -v response '%s' "$(_make_gitlab_api_call "$url")"
     [[ -z "$response" ]] && return 1
 
     local count
@@ -248,11 +241,9 @@ _count_issues() {
 
 _count_mrs() {
     local project_encoded="$1"
-    local gitlab_url=$(get_option "url")
-
+    printf -v gitlab_url '%s' "$(get_option "url")"
     local url="${gitlab_url}/api/v4/projects/${project_encoded}/merge_requests?state=opened&per_page=1"
-    local response=$(_make_gitlab_head_call "$url")
-
+    printf -v response '%s' "$(_make_gitlab_head_call "$url")"
     [[ -z "$response" ]] && return 1
 
     local count=$(echo "$response" | grep -i '^x-total:' | awk '{print $2}' | tr -d '\r\n')
@@ -263,9 +254,8 @@ _count_mrs() {
 
 # Use glab CLI if available and no repos configured
 _fetch_via_glab_cli() {
-    local show_issues=$(get_option "show_issues")
-    local show_mrs=$(get_option "show_mrs")
-
+    printf -v show_issues '%s' "$(get_option "show_issues")"
+    printf -v show_mrs '%s' "$(get_option "show_mrs")"
     local issues=0 mrs=0
 
     if [[ "$show_mrs" == "true" ]]; then
@@ -287,12 +277,11 @@ _format_status() {
     local issues="$1"
     local mrs="$2"
 
-    local show_issues=$(get_option "show_issues")
-    local show_mrs=$(get_option "show_mrs")
-    local separator=$(get_option "separator")
-    local icon_issue=$(get_option "icon_issue")
-    local icon_mr=$(get_option "icon_mr")
-
+    printf -v show_issues '%s' "$(get_option "show_issues")"
+    printf -v show_mrs '%s' "$(get_option "show_mrs")"
+    printf -v separator '%s' "$(get_option "separator")"
+    printf -v icon_issue '%s' "$(get_option "icon_issue")"
+    printf -v icon_mr '%s' "$(get_option "icon_mr")"
     local parts=()
 
     if [[ "$show_issues" == "true" && "$issues" -gt 0 ]]; then
@@ -315,13 +304,12 @@ _format_status() {
 }
 
 _get_gitlab_info() {
-    local repos_csv=$(get_option "repos")
-    local show_issues=$(get_option "show_issues")
-    local show_mrs=$(get_option "show_mrs")
-
+    printf -v repos_csv '%s' "$(get_option "repos")"
+    printf -v show_issues '%s' "$(get_option "show_issues")"
+    printf -v show_mrs '%s' "$(get_option "show_mrs")"
     # If no repos configured, try glab CLI
     if [[ -z "$repos_csv" ]] && has_cmd glab; then
-        local result=$(_fetch_via_glab_cli)
+        printf -v result '%s' "$(_fetch_via_glab_cli)"
         echo "$result 0" # issues mrs api_error
         return 0
     fi
@@ -340,7 +328,7 @@ _get_gitlab_info() {
         repo_spec=$(trim "$repo_spec")
         [[ -z "$repo_spec" || "$repo_spec" != *"/"* ]] && continue
 
-        local project_encoded=$(_url_encode "$repo_spec")
+        printf -v project_encoded '%s' "$(_url_encode "$repo_spec")"
         local issues=0 mrs=0
 
         if [[ "$show_issues" == "true" ]]; then
@@ -376,7 +364,7 @@ plugin_collect() {
         return 0
     fi
 
-    local result=$(_get_gitlab_info)
+    printf -v result '%s' "$(_get_gitlab_info)"
     local issues mrs api_error
     read -r issues mrs api_error <<<"$result"
 
@@ -403,10 +391,9 @@ plugin_render() {
         return 0
     fi
 
-    local issues=$(plugin_data_get "issues")
-    local mrs=$(plugin_data_get "mrs")
-    local total=$(plugin_data_get "total")
-
+    printf -v issues '%s' "$(plugin_data_get "issues")"
+    printf -v mrs '%s' "$(plugin_data_get "mrs")"
+    printf -v total '%s' "$(plugin_data_get "total")"
     issues="${issues:-0}"
     mrs="${mrs:-0}"
     total="${total:-0}"

--- a/src/plugins/gitlab.sh
+++ b/src/plugins/gitlab.sh
@@ -209,14 +209,20 @@ _make_gitlab_api_call() {
     local url="$1"
     local token=$(_get_token)
 
-    make_api_call "$url" "private-token" "$token" 5
+    # PRIVATE-TOKEN is passed via curl --config (stdin) so it never
+    # appears in process argv. The body returned here is the same
+    # JSON shape as make_api_call would have given.
+    api_fetch_with_token_header "$url" "PRIVATE-TOKEN" "$token" 5
 }
 
 _make_gitlab_head_call() {
     local url="$1"
     local token=$(_get_token)
 
-    safe_curl "$url" 5 -I -H "PRIVATE-TOKEN: $token"
+    # Same credential-safe transport for HEAD requests. The header is
+    # forwarded via stdin; only the URL is in argv.
+    printf 'header = "PRIVATE-TOKEN: %s"\nheader = "X-Head-Only: 1"\nrequest = "HEAD"\n' "$token" |
+        curl -sf --config - --connect-timeout 5 --max-time 10 "$url" 2>/dev/null
 }
 
 _count_issues() {

--- a/src/plugins/gpu.sh
+++ b/src/plugins/gpu.sh
@@ -113,9 +113,9 @@ plugin_get_health() {
     usage_warn="${usage_warn:-70}"
     usage_crit="${usage_crit:-90}"
 
-    if (( usage >= usage_crit )); then
+    if ((usage >= usage_crit)); then
         health="error"
-    elif (( usage >= usage_warn )); then
+    elif ((usage >= usage_warn)); then
         [[ "$health" != "error" ]] && health="warning"
     fi
 
@@ -129,10 +129,10 @@ plugin_get_health() {
     mem_crit="${mem_crit:-90}"
 
     if [[ "${mem_total:-0}" -gt 0 ]]; then
-        mem_percent=$(( (mem_used * 100) / mem_total ))
-        if (( mem_percent >= mem_crit )); then
+        mem_percent=$(((mem_used * 100) / mem_total))
+        if ((mem_percent >= mem_crit)); then
             health="error"
-        elif (( mem_percent >= mem_warn )); then
+        elif ((mem_percent >= mem_warn)); then
             [[ "$health" != "error" ]] && health="warning"
         fi
     fi
@@ -146,9 +146,9 @@ plugin_get_health() {
     temp_warn="${temp_warn:-70}"
     temp_crit="${temp_crit:-85}"
 
-    if (( temp >= temp_crit )); then
+    if ((temp >= temp_crit)); then
         health="error"
-    elif (( temp >= temp_warn )); then
+    elif ((temp >= temp_warn)); then
         [[ "$health" != "error" ]] && health="warning"
     fi
 
@@ -158,12 +158,12 @@ plugin_get_health() {
 plugin_get_context() {
     local usage=$(plugin_data_get "usage")
     usage="${usage:-0}"
-    
-    if (( usage == 0 )); then
+
+    if ((usage == 0)); then
         printf 'idle'
-    elif (( usage < 30 )); then
+    elif ((usage < 30)); then
         printf 'light'
-    elif (( usage < 70 )); then
+    elif ((usage < 70)); then
         printf 'moderate'
     else
         printf 'heavy'
@@ -199,8 +199,8 @@ _collect_intel_gpu() {
     [[ -z "$freq_cur" || -z "$freq_max" ]] && return 1
 
     # Calculate usage as percentage of max frequency
-    if (( freq_max > 0 )); then
-        usage=$(( (freq_cur * 100) / freq_max ))
+    if ((freq_max > 0)); then
+        usage=$(((freq_cur * 100) / freq_max))
     else
         usage=0
     fi
@@ -242,24 +242,30 @@ plugin_collect() {
             # Get temperature
             temp=$("$powerkit_gpu" -t 2>/dev/null)
 
-            [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && { available=1; gpu_type="macos"; }
+            [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && {
+                available=1
+                gpu_type="macos"
+            }
         fi
     else
         # Linux: NVIDIA GPU via nvidia-smi
         if has_cmd "nvidia-smi"; then
-            # Check if nvidia-smi works (driver might be broken/mismatched)
-            if nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | grep -q .; then
-                usage=$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits 2>/dev/null | head -1)
-                temp=$(nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits 2>/dev/null | head -1)
-
-                # Get memory used/total in MB
-                local mem_used mem_total
-                mem_used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1)
-                mem_total=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1)
+            # Check if nvidia-smi works (driver might be broken/mismatched),
+            # AND batch-collect all metrics in a single invocation (Sprint 2.10:
+            # reduces ~5 forks to 1). The query returns 5 CSV rows of 5 columns;
+            # we read just the first GPU (head -1) for simplicity.
+            local nvidia_csv
+            nvidia_csv=$(nvidia-smi --query-gpu=utilization.gpu,temperature.gpu,memory.used,memory.total,name \
+                --format=csv,noheader,nounits 2>/dev/null | head -1)
+            if [[ -n "$nvidia_csv" ]]; then
+                IFS=',' read -r usage temp mem_used mem_total _ <<<"$nvidia_csv"
                 mem_used_mb="${mem_used:-0}"
                 mem_total_mb="${mem_total:-0}"
 
-                [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && { available=1; gpu_type="nvidia"; }
+                [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && {
+                    available=1
+                    gpu_type="nvidia"
+                }
             fi
         fi
 
@@ -277,7 +283,7 @@ plugin_collect() {
                 if [[ -n "$hwmon_dir" && -f "${hwmon_dir}/temp1_input" ]]; then
                     local temp_milli
                     temp_milli=$(cat "${hwmon_dir}/temp1_input" 2>/dev/null)
-                    temp=$(( temp_milli / 1000 ))
+                    temp=$((temp_milli / 1000))
                 fi
 
                 # AMD VRAM via drm (if available)
@@ -286,11 +292,14 @@ plugin_collect() {
                     vram_used=$(cat "${amd_gpu_dir}/mem_info_vram_used" 2>/dev/null)
                     vram_total=$(cat "${amd_gpu_dir}/mem_info_vram_total" 2>/dev/null)
                     # Convert bytes to MB
-                    mem_used_mb=$(( vram_used / 1048576 ))
-                    mem_total_mb=$(( vram_total / 1048576 ))
+                    mem_used_mb=$((vram_used / 1048576))
+                    mem_total_mb=$((vram_total / 1048576))
                 fi
 
-                [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && { available=1; gpu_type="amd"; }
+                [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && {
+                    available=1
+                    gpu_type="amd"
+                }
             fi
         fi
 
@@ -300,7 +309,7 @@ plugin_collect() {
             intel_dir=$(_find_intel_gpu_dir)
             if [[ -n "$intel_dir" ]]; then
                 _collect_intel_gpu "$intel_dir"
-                return  # Intel collection sets all data internally
+                return # Intel collection sets all data internally
             fi
         fi
     fi
@@ -316,9 +325,9 @@ plugin_collect() {
 # Format MB to human-readable (M or G)
 _format_memory_value() {
     local mb="$1"
-    if (( mb >= 1024 )); then
-        local gb_int=$(( mb / 1024 ))
-        local gb_dec=$(( (mb % 1024) * 10 / 1024 ))
+    if ((mb >= 1024)); then
+        local gb_int=$((mb / 1024))
+        local gb_dec=$(((mb % 1024) * 10 / 1024))
         printf '%d.%dG' "$gb_int" "$gb_dec"
     else
         printf '%dM' "$mb"
@@ -331,30 +340,30 @@ _format_memory() {
     local format="$3"
 
     case "$format" in
-        memory_usage)
-            # Format: used / allocated (e.g., "409M / 4.1G")
-            local used_str total_str
-            used_str="$(_format_memory_value "${mem_used_mb:-0}")"
-            total_str="$(_format_memory_value "${mem_total_mb:-0}")"
-            printf '%s/%s' "$used_str" "$total_str"
-            ;;
-        memory_percentage)
-            # Format: percentage of allocation (e.g., "10%")
-            if [[ "${mem_total_mb:-0}" -gt 0 ]]; then
-                local percent=$(( (mem_used_mb * 100) / mem_total_mb ))
-                printf '%d%%' "$percent"
-            else
-                printf '0%%'
-            fi
-            ;;
-        memory_use|*)
-            # Format: only used (e.g., "409M")
-            if [[ -n "$mem_used_mb" && "$mem_used_mb" != "0" ]]; then
-                _format_memory_value "$mem_used_mb"
-            else
-                printf '0M'
-            fi
-            ;;
+    memory_usage)
+        # Format: used / allocated (e.g., "409M / 4.1G")
+        local used_str total_str
+        used_str="$(_format_memory_value "${mem_used_mb:-0}")"
+        total_str="$(_format_memory_value "${mem_total_mb:-0}")"
+        printf '%s/%s' "$used_str" "$total_str"
+        ;;
+    memory_percentage)
+        # Format: percentage of allocation (e.g., "10%")
+        if [[ "${mem_total_mb:-0}" -gt 0 ]]; then
+            local percent=$(((mem_used_mb * 100) / mem_total_mb))
+            printf '%d%%' "$percent"
+        else
+            printf '0%%'
+        fi
+        ;;
+    memory_use | *)
+        # Format: only used (e.g., "409M")
+        if [[ -n "$mem_used_mb" && "$mem_used_mb" != "0" ]]; then
+            _format_memory_value "$mem_used_mb"
+        else
+            printf '0M'
+        fi
+        ;;
     esac
 }
 
@@ -402,40 +411,39 @@ plugin_render() {
     # Build parts array based on requested metrics
     local IFS=','
     local requested_metrics
-    read -ra requested_metrics <<< "$metric"
+    read -ra requested_metrics <<<"$metric"
 
     for m in "${requested_metrics[@]}"; do
         # Trim whitespace
         m="${m// /}"
         case "$m" in
-            usage)
-                parts+=("${icon_usage}${usage:-0}%")
-                ;;
-            memory)
-                # Skip memory for Intel (uses shared system memory)
-                [[ "$gpu_type" == "intel" ]] && continue
-                parts+=("${icon_memory}${memory_str}")
-                ;;
-            temp)
-                # Skip temp for Intel if not available
-                [[ "$gpu_type" == "intel" ]] && continue
-                parts+=("${icon_temp}${temp:-0}°C")
-                ;;
-            freq)
-                # Frequency metric (mainly useful for Intel)
-                if [[ -n "$freq_cur" ]]; then
-                    parts+=("${icon_freq}${freq_cur}/${freq_max}MHz")
-                fi
-                ;;
+        usage)
+            parts+=("${icon_usage}${usage:-0}%")
+            ;;
+        memory)
+            # Skip memory for Intel (uses shared system memory)
+            [[ "$gpu_type" == "intel" ]] && continue
+            parts+=("${icon_memory}${memory_str}")
+            ;;
+        temp)
+            # Skip temp for Intel if not available
+            [[ "$gpu_type" == "intel" ]] && continue
+            parts+=("${icon_temp}${temp:-0}°C")
+            ;;
+        freq)
+            # Frequency metric (mainly useful for Intel)
+            if [[ -n "$freq_cur" ]]; then
+                parts+=("${icon_freq}${freq_cur}/${freq_max}MHz")
+            fi
+            ;;
         esac
     done
 
     # Output parts with separator
     local first=1
     for part in "${parts[@]}"; do
-        (( first )) || printf '%s' "$separator"
+        ((first)) || printf '%s' "$separator"
         printf '%s' "$part"
         first=0
     done
 }
-

--- a/src/plugins/iops.sh
+++ b/src/plugins/iops.sh
@@ -80,16 +80,16 @@ plugin_get_context() {
     read_rate=$(plugin_data_get "read_rate")
     write_rate=$(plugin_data_get "write_rate")
     total_rate=$(plugin_data_get "total_rate")
-    
+
     read_rate="${read_rate:-0}"
     write_rate="${write_rate:-0}"
     total_rate="${total_rate:-0}"
-    
-    if (( total_rate == 0 )); then
+
+    if ((total_rate == 0)); then
         printf 'idle'
-    elif (( read_rate > write_rate * 2 )); then
+    elif ((read_rate > write_rate * 2)); then
         printf 'read_heavy'
-    elif (( write_rate > read_rate * 2 )); then
+    elif ((write_rate > read_rate * 2)); then
         printf 'write_heavy'
     else
         printf 'balanced'
@@ -104,47 +104,50 @@ plugin_get_icon() { get_option "icon"; }
 
 _get_throughput_macos() {
     local now=$EPOCHSECONDS
-    
+
     # Get current bytes from ioreg (all disks combined)
     local stats
     stats=$(ioreg -c IOBlockStorageDriver -r -w 0 2>/dev/null | grep -o '"Statistics" = {[^}]*}')
-    
-    [[ -z "$stats" ]] && { printf '0|0'; return 1; }
-    
+
+    [[ -z "$stats" ]] && {
+        printf '0|0'
+        return 1
+    }
+
     # Sum bytes from all disks
     local total_read_bytes=0
     local total_write_bytes=0
-    
+
     while IFS= read -r line; do
         local read_bytes write_bytes
         read_bytes=$(echo "$line" | grep -o '"Bytes (Read)"=[0-9]*' | grep -o '[0-9]*')
         write_bytes=$(echo "$line" | grep -o '"Bytes (Write)"=[0-9]*' | grep -o '[0-9]*')
         total_read_bytes=$((total_read_bytes + ${read_bytes:-0}))
         total_write_bytes=$((total_write_bytes + ${write_bytes:-0}))
-    done <<< "$stats"
-    
+    done <<<"$stats"
+
     # Read previous state from cache
     local prev_state prev_time=0 prev_read=0 prev_write=0
     if prev_state=$(cache_get "iops_state" 86400); then
-        IFS='|' read -r prev_time prev_read prev_write <<< "$prev_state"
+        IFS='|' read -r prev_time prev_read prev_write <<<"$prev_state"
     fi
-    
+
     # Save current state to cache
     cache_set "iops_state" "${now}|${total_read_bytes}|${total_write_bytes}"
-    
+
     # Calculate delta (bytes per second)
     local time_delta=$((now - prev_time))
-    if (( time_delta > 0 && prev_time > 0 )); then
+    if ((time_delta > 0 && prev_time > 0)); then
         local read_delta=$((total_read_bytes - prev_read))
         local write_delta=$((total_write_bytes - prev_write))
-        
+
         # Avoid negative values (can happen on system restart)
-        (( read_delta < 0 )) && read_delta=0
-        (( write_delta < 0 )) && write_delta=0
-        
+        ((read_delta < 0)) && read_delta=0
+        ((write_delta < 0)) && write_delta=0
+
         local read_rate=$((read_delta / time_delta))
         local write_rate=$((write_delta / time_delta))
-        
+
         printf '%d|%d' "$read_rate" "$write_rate"
     else
         # First run, no delta available
@@ -157,8 +160,8 @@ _get_util_macos() {
     total_rate=$(plugin_data_get "total_rate")
     total_rate="${total_rate:-0}"
 
-    local pseudo_util=$(( total_rate / 10485760 ))
-    (( pseudo_util > 100 )) && pseudo_util=100
+    local pseudo_util=$((total_rate / 10485760))
+    ((pseudo_util > 100)) && pseudo_util=100
     printf '%d' "$pseudo_util"
 }
 
@@ -168,22 +171,25 @@ _get_util_macos() {
 
 _get_throughput_linux() {
     local now=$EPOCHSECONDS
-    
+
     # Read from /proc/diskstats (sectors read/written)
     # Format: major minor name reads_completed reads_merged sectors_read ms_reading writes_completed writes_merged sectors_written ...
     local stats
     stats=$(cat /proc/diskstats 2>/dev/null)
-    
-    [[ -z "$stats" ]] && { printf '0|0'; return 1; }
-    
+
+    [[ -z "$stats" ]] && {
+        printf '0|0'
+        return 1
+    }
+
     # Sum sectors from all real disks (sd*, nvme*, vd*)
     local total_read_sectors=0
     local total_write_sectors=0
-    
+
     while IFS= read -r line; do
         local name read_sectors write_sectors
         name=$(echo "$line" | awk '{print $3}')
-        
+
         # Only count main disks, not partitions (sda not sda1, nvme0n1 not nvme0n1p1)
         if [[ "$name" =~ ^(sd[a-z]|nvme[0-9]+n[0-9]+|vd[a-z])$ ]]; then
             read_sectors=$(echo "$line" | awk '{print $6}')
@@ -191,34 +197,34 @@ _get_throughput_linux() {
             total_read_sectors=$((total_read_sectors + ${read_sectors:-0}))
             total_write_sectors=$((total_write_sectors + ${write_sectors:-0}))
         fi
-    done <<< "$stats"
-    
+    done <<<"$stats"
+
     # Convert sectors to bytes (sector = 512 bytes)
     local total_read_bytes=$((total_read_sectors * 512))
     local total_write_bytes=$((total_write_sectors * 512))
-    
+
     # Read previous state from cache
     local prev_state prev_time=0 prev_read=0 prev_write=0
     if prev_state=$(cache_get "iops_state" 86400); then
-        IFS='|' read -r prev_time prev_read prev_write <<< "$prev_state"
+        IFS='|' read -r prev_time prev_read prev_write <<<"$prev_state"
     fi
-    
+
     # Save current state to cache
     cache_set "iops_state" "${now}|${total_read_bytes}|${total_write_bytes}"
-    
+
     # Calculate delta (bytes per second)
     local time_delta=$((now - prev_time))
-    if (( time_delta > 0 && prev_time > 0 )); then
+    if ((time_delta > 0 && prev_time > 0)); then
         local read_delta=$((total_read_bytes - prev_read))
         local write_delta=$((total_write_bytes - prev_write))
-        
+
         # Avoid negative values
-        (( read_delta < 0 )) && read_delta=0
-        (( write_delta < 0 )) && write_delta=0
-        
+        ((read_delta < 0)) && read_delta=0
+        ((write_delta < 0)) && write_delta=0
+
         local read_rate=$((read_delta / time_delta))
         local write_rate=$((write_delta / time_delta))
-        
+
         printf '%d|%d' "$read_rate" "$write_rate"
     else
         printf '0|0'
@@ -226,17 +232,17 @@ _get_throughput_linux() {
 }
 
 _get_util_linux() {
-    local now=${EPOCHSECONDS:-$(date +%s)}
+    local now=${EPOCHSECONDS}
 
     local total_io_ms=0
     while IFS= read -r line; do
         local fields
-        read -ra fields <<< "$line"
+        read -ra fields <<<"$line"
         local dev="${fields[2]}"
         [[ "$dev" =~ ^(loop|dm-|sr) ]] && continue
         local io_ms="${fields[12]:-0}"
         total_io_ms=$((total_io_ms + io_ms))
-    done < /proc/diskstats 2>/dev/null
+    done </proc/diskstats 2>/dev/null
 
     local prev_io_ms prev_time
     prev_io_ms=$(cache_get "iops_util_io_ms" 86400)
@@ -245,16 +251,19 @@ _get_util_linux() {
     cache_set "iops_util_io_ms" "$total_io_ms"
     cache_set "iops_util_time" "$now"
 
-    [[ -z "$prev_io_ms" || -z "$prev_time" ]] && { printf '0'; return; }
+    [[ -z "$prev_io_ms" || -z "$prev_time" ]] && {
+        printf '0'
+        return
+    }
 
     local delta_io=$((total_io_ms - prev_io_ms))
-    local delta_time=$(( (now - prev_time) * 1000 ))
+    local delta_time=$(((now - prev_time) * 1000))
 
-    (( delta_io < 0 )) && delta_io=0
+    ((delta_io < 0)) && delta_io=0
 
-    if (( delta_time > 0 )); then
-        local util=$(( delta_io * 100 / delta_time ))
-        (( util > 100 )) && util=100
+    if ((delta_time > 0)); then
+        local util=$((delta_io * 100 / delta_time))
+        ((util > 100)) && util=100
         printf '%d' "$util"
     else
         printf '0'
@@ -278,7 +287,7 @@ plugin_collect() {
     data=$(_get_throughput)
 
     local read_rate write_rate
-    IFS='|' read -r read_rate write_rate <<< "$data"
+    IFS='|' read -r read_rate write_rate <<<"$data"
 
     read_rate="${read_rate:-0}"
     write_rate="${write_rate:-0}"
@@ -314,4 +323,3 @@ plugin_render() {
 
     [[ ${#parts[@]} -gt 0 ]] && join_with_separator "$separator" "${parts[@]}"
 }
-

--- a/src/plugins/jira.sh
+++ b/src/plugins/jira.sh
@@ -201,12 +201,21 @@ _fetch_jira_breakdown() {
     local flagged=0
     local next_token=""
 
+    # Avoid exposing email+token in process argv. The credential pair
+    # is written to a mode-600 temp curl config and removed via a RETURN
+    # trap; the URL stays in argv, not the secret.
+    local jira_creds
+    jira_creds=$(mktemp "${TMPDIR:-/tmp}/powerkit-jira.XXXXXX") || return 1
+    chmod 600 "$jira_creds"
+    printf -- '-u %s:%s\n' "$email" "$token" >"$jira_creds"
+    trap 'rm -f "$jira_creds"' RETURN
+
     # Paginate through results
     while true; do
-        # Build curl args with URL-encoded parameters via --data-urlencode
+        # Build curl args; the credential pair is in $jira_creds (not argv)
         local curl_args=(
             -sf --connect-timeout 10 --max-time 20
-            -u "${email}:${token}"
+            --config "$jira_creds"
             -H "Content-Type: application/json"
             -H "Accept: application/json"
             --get
@@ -221,7 +230,14 @@ _fetch_jira_breakdown() {
 
         [[ -z "$response" ]] && return 1
 
-        # Check for errors
+        # Validate JSON shape before iterating. A malformed body must
+        # NOT silently yield zero counts; that would replace the prior
+        # cache with bogus data instead of leaving it stale.
+        if ! api_validate_json "$response"; then
+            return 1
+        fi
+
+        # Check for Jira's structured error field
         if echo "$response" | jq -e '.errorMessages' &>/dev/null; then
             return 1
         fi

--- a/src/plugins/nowplaying.sh
+++ b/src/plugins/nowplaying.sh
@@ -47,6 +47,11 @@ plugin_declare_options() {
     # Behavior
     declare_option "info_when_paused" "bool" "false" "Use info health when paused"
 
+    # Comma-separated app priority order (Linux only). The first
+    # available player in this list wins; lower-priority players are
+    # ignored. Empty means accept whatever is currently playing.
+    declare_option "app_priority" "string" "" "Priority order of player names (Linux only)"
+
     # Icons
     declare_option "icon" "icon" $'\U000F075A' "Plugin icon (music note)"
     declare_option "icon_paused" "icon" $'\U000F03E6' "Paused icon"
@@ -189,6 +194,26 @@ _get_nowplaying_linux() {
     state_raw=$(playerctl "${playerctl_args[@]}" status 2>/dev/null)
     [[ -z "$state_raw" ]] && return 1
     state="${state_raw,,}"  # Bash 4.0+ lowercase
+
+    # When a priority list is configured, ignore every player that is
+    # not in the list so the highest-priority one always wins.
+    local app_priority
+    app_priority=$(get_option "app_priority")
+    if [[ -n "$app_priority" ]]; then
+        local priority_player=""
+        local IFS=','
+        local p
+        for p in $app_priority; do
+            p=$(trim "$p")
+            if playerctl "${playerctl_args[@]}" status --player "$p" 2>/dev/null | grep -qi .; then
+                priority_player="$p"
+                break
+            fi
+        done
+        if [[ -n "$priority_player" ]]; then
+            playerctl_args+=("--player=$priority_player")
+        fi
+    fi
 
     # Get all metadata in one call using format string
     local metadata

--- a/src/plugins/nowplaying.sh
+++ b/src/plugins/nowplaying.sh
@@ -150,8 +150,17 @@ _get_nowplaying_macos() {
     local binary="${POWERKIT_ROOT}/bin/powerkit-nowplaying"
     [[ -x "$binary" ]] || return 1
 
+    # Forward the app_priority option to the binary so the operator
+    # can pin a preferred player when several are running. The binary
+    # accepts the same comma-separated list format as playerctl.
+    local app_priority priority_args=()
+    app_priority=$(get_option "app_priority")
+    if [[ -n "$app_priority" ]]; then
+        priority_args=(-p "$app_priority")
+    fi
+
     local output
-    output=$("$binary" 2>/dev/null) || return 1
+    output=$("$binary" "${priority_args[@]}" 2>/dev/null) || return 1
     [[ -z "$output" ]] && return 1
 
     # Check if app should be ignored

--- a/src/plugins/stocks.sh
+++ b/src/plugins/stocks.sh
@@ -188,17 +188,18 @@ _fetch_stock_price() {
 # Formatting Functions
 # =============================================================================
 
-# Format price for display
+# Format price for display (pure bash, no awk fork)
 _format_price() {
     local price="$1"
     local format="$2"
 
     if [[ "$format" == "short" ]]; then
         # Short format: no $ sign, round large numbers
-        if awk -v p="$price" 'BEGIN { exit (p >= 1000) ? 0 : 1 }' 2>/dev/null; then
-            awk -v p="$price" 'BEGIN { printf "%.0f", p }'
+        # Shift decimal 2 places, integer math, then format.
+        if (($(printf '%.0f' "$price") >= 1000)); then
+            printf '%.0f' "$price"
         else
-            awk -v p="$price" 'BEGIN { printf "%.2f", p }'
+            printf '%.2f' "$price"
         fi
     else
         # Full format: with $ sign
@@ -206,22 +207,52 @@ _format_price() {
     fi
 }
 
-# Format change with direction indicator
+# Format change with direction indicator (pure bash, no awk fork)
 _format_change() {
     local change="$1"
     local indicator=""
 
-    # Determine direction
-    if awk -v c="$change" 'BEGIN { exit (c > 0.01) ? 0 : 1 }' 2>/dev/null; then
-        indicator="↑"
-    elif awk -v c="$change" 'BEGIN { exit (c < -0.01) ? 0 : 1 }' 2>/dev/null; then
-        indicator="↓"
-        change="${change#-}" # Remove negative sign for display
+    # Split "[-]X.Y[Z...]" into integer and fractional parts without awk.
+    local sign="" int_part frac_part
+    if [[ "$change" == -* ]]; then
+        sign="-"
+        change="${change#-}"
+    fi
+    int_part="${change%%.*}"
+    [[ "$int_part" == "$change" ]] && int_part="${change}" || int_part="${int_part:-0}"
+    frac_part="${change#*.}"
+    [[ "$frac_part" == "$change" ]] && frac_part="0"
+
+    # One decimal digit for display (matches original "%.1f%%").
+    local d1="${frac_part:0:1}"
+    d1="${d1:-0}"
+
+    # Determine direction from sign and magnitude using integer math.
+    # Treat |change| >= 0.05 as movement; below that is flat.
+    local int_cmp=0
+    if ((${#frac_part} == 0)); then
+        int_cmp=$((10#$int_part))
     else
-        indicator="→"
+        # Compare |change| to 0.05 using integer cents: 5 cents = 0.05
+        local cents=$((10#${int_part:-0} * 100 + 10#${frac_part:0:2}))
+        ((${#frac_part} < 2)) && cents=$((cents * 10))
+        ((${#frac_part} > 2)) && cents=$((cents / 10 ** (${#frac_part} - 2)))
+        int_cmp=$cents
     fi
 
-    printf '%s%.1f%%' "$indicator" "$change"
+    if [[ -n "$sign" ]]; then
+        # Original was negative; display as ↓ with magnitude (no sign prefix).
+        indicator="↓"
+        change="${int_part}.${d1}"
+    elif ((int_cmp > 5)); then
+        indicator="↑"
+        change="${int_part}.${d1}"
+    else
+        indicator="→"
+        change="${int_part}.${d1}"
+    fi
+
+    printf '%s%s%%' "$indicator" "$change"
 }
 
 # =============================================================================

--- a/src/plugins/stocks.sh
+++ b/src/plugins/stocks.sh
@@ -144,16 +144,38 @@ _fetch_stock_price() {
 
     [[ -z "$response" ]] && return 1
 
-    # Parse JSON manually (no jq dependency)
+    # Validate JSON shape before regex extraction. The previous code
+    # applied a sed pattern to whatever the server returned, which
+    # silently succeeded on HTML error pages, captive portals, or 429
+    # bodies. A successful empty grep is what produced zero prices
+    # without raising the cache.
+    if has_cmd jq; then
+        api_validate_json "$response" || return 1
+        # Use jq's structural path so we do not depend on a regex that
+        # the provider can change at any release.
+        local price prev_close
+        price=$(printf '%s' "$response" | jq -r '.chart.result[0].meta.regularMarketPrice // empty' 2>/dev/null) || return 1
+        prev_close=$(printf '%s' "$response" | jq -r '.chart.result[0].meta.chartPreviousClose // empty' 2>/dev/null) || return 1
+        [[ -z "$price" ]] && return 1
+
+        local change_pct
+        if [[ -n "$prev_close" && "$prev_close" != "0" ]]; then
+            change_pct=$(awk -v p="$price" -v pc="$prev_close" 'BEGIN { printf "%.2f", ((p - pc) / pc) * 100 }')
+        else
+            change_pct="0.00"
+        fi
+        printf '%s|%s' "$price" "$change_pct"
+        return 0
+    fi
+
+    # Fallback: regex parsing (kept for environments without jq).
     local price prev_close change_pct
     price=$(echo "$response" | sed -n 's/.*"regularMarketPrice":\([0-9.]*\).*/\1/p' | head -1)
     prev_close=$(echo "$response" | sed -n 's/.*"chartPreviousClose":\([0-9.]*\).*/\1/p' | head -1)
 
     [[ -z "$price" ]] && return 1
 
-    # Calculate change percentage
     if [[ -n "$prev_close" && "$prev_close" != "0" ]]; then
-        # Use awk for floating point calculation
         change_pct=$(awk -v p="$price" -v pc="$prev_close" 'BEGIN { printf "%.2f", ((p - pc) / pc) * 100 }')
     else
         change_pct="0.00"
@@ -216,13 +238,17 @@ plugin_collect() {
     IFS=',' read -ra ticker_list <<<"$tickers"
 
     local prices_data="" changes_data=""
+    local attempted=0 parsed=0
     for ticker in "${ticker_list[@]}"; do
         ticker=$(trim "$ticker")
         ticker="${ticker^^}" # Bash 4.0+ uppercase
         [[ -z "$ticker" ]] && continue
 
+        ((attempted++))
         local stock_data
-        stock_data=$(_fetch_stock_price "$ticker")
+        if ! stock_data=$(_fetch_stock_price "$ticker"); then
+            continue
+        fi
 
         if [[ -n "$stock_data" ]]; then
             IFS='|' read -r price change <<<"$stock_data"
@@ -231,8 +257,16 @@ plugin_collect() {
 
             [[ -n "$changes_data" ]] && changes_data+="|"
             changes_data+="${ticker}:${change}"
+            ((parsed++))
         fi
     done
+
+    # When no ticker produced a price, refuse to overwrite the prior
+    # cache so the lifecycle can keep the previous record and mark it
+    # stale.
+    if ((attempted > 0 && parsed == 0)); then
+        return 1
+    fi
 
     [[ -n "$prices_data" ]] && plugin_data_set "prices" "$prices_data"
     [[ -n "$changes_data" ]] && plugin_data_set "changes" "$changes_data"

--- a/src/plugins/swap.sh
+++ b/src/plugins/swap.sh
@@ -47,9 +47,6 @@ plugin_declare_options() {
 
     # Cache
     declare_option "cache_ttl" "number" "30" "Cache duration in seconds"
-
-    # Optional: Include compressed memory (macOS only)
-    declare_option "include_compressed" "bool" "false" "Include compressed memory in swap total (macOS only)"
 }
 
 # =============================================================================
@@ -164,15 +161,25 @@ _collect_macos() {
     return 1
 }
 
-# Helper to convert value with unit to bytes
+# Helper to convert a decimal value with a unit suffix to bytes.
+# macOS sysctl reports values like "1234.50M", "0.75G", "2.00T".
+# The previous implementation used ${value%.*} which truncated the
+# decimal portion, so "1234.5" became 1234 and could even collapse
+# to zero when the integer part was less than 1. Use awk for floating
+# point math so the original precision is preserved.
 _to_bytes() {
     local value="$1"
     local unit="$2"
 
+    if ! printf '%s' "$value" | grep -Eq '^[0-9]+(\.[0-9]+)?$'; then
+        echo "0"
+        return
+    fi
+
     case "$unit" in
-    M) echo "$((${value%.*} * 1024 * 1024))" ;;
-    G) echo "$((${value%.*} * 1024 * 1024 * 1024))" ;;
-    T) echo "$((${value%.*} * 1024 * 1024 * 1024 * 1024))" ;;
+    M) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 }' ;;
+    G) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 * 1024 }' ;;
+    T) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 * 1024 * 1024 }' ;;
     *) echo "0" ;;
     esac
 }

--- a/src/plugins/uptime.sh
+++ b/src/plugins/uptime.sh
@@ -8,7 +8,6 @@
 POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "${POWERKIT_ROOT}/src/contract/plugin_contract.sh"
 
-
 plugin_get_metadata() {
     metadata_set "id" "uptime"
     metadata_set "name" "Uptime"
@@ -21,7 +20,6 @@ plugin_declare_options() {
     # Cache - uptime changes slowly, no need for frequent updates
     declare_option "cache_ttl" "number" "300" "Cache duration in seconds"
 }
-
 
 plugin_get_content_type() { printf 'dynamic'; }
 plugin_get_presence() { printf 'always'; }
@@ -41,7 +39,7 @@ plugin_get_context() {
 }
 
 plugin_collect() {
-    local uptime_seconds=0
+    local uptime_seconds=""
     if is_linux && [[ -r /proc/uptime ]]; then
         uptime_seconds=$(awk '{printf "%d", $1}' /proc/uptime 2>/dev/null)
     elif is_macos; then
@@ -52,10 +50,40 @@ plugin_collect() {
             ((uptime_seconds = now - boot_time))
         fi
     else
-        # Fallback: parse uptime output
-        uptime_seconds=$(uptime | awk -F'( |,|:)+' '{if ($7=="min") print $6*60; else if ($7=="hrs") print $6*3600; else print 0}')
+        # Fallback: parse uptime output. The canonical uptime layout
+        # (after the "hh:mm" prefix) is "up N day(s), hh:mm, N users,
+        # load averages: ...". With FS='( |,|:)+', the field layout
+        # is: $1=hh, $2=mm, $3=up, $4=count, $5=unit. Days may be
+        # followed by an additional hh:mm at $6 and $7. Returning -1
+        # on anything unparseable lets the caller fail collection so
+        # the lifecycle can keep the previous record as stale.
+        uptime_seconds=$(uptime | awk -F'( |,|:)+' '
+            {
+                if ($5 == "min" || $5 == "mins") {
+                    print $4 * 60
+                } else if ($5 == "hrs") {
+                    print $4 * 3600
+                } else if ($5 == "day" || $5 == "days") {
+                    base = $4 * 86400
+                    if ($6 ~ /^[0-9]+$/ && $7 ~ /^[0-9]+$/) {
+                        base += ($6 * 3600) + ($7 * 60)
+                    }
+                    print base
+                } else {
+                    print -1
+                }
+            }')
+        if [[ "$uptime_seconds" == "-1" ]]; then
+            return 1
+        fi
     fi
-    plugin_data_set "uptime" "$(format_uptime_seconds "${uptime_seconds:-0}")"
+    # If every branch failed to populate uptime_seconds, fail collection
+    # so the lifecycle can keep the previous record as stale instead of
+    # reporting 0m which is indistinguishable from a fresh boot.
+    if [[ -z "$uptime_seconds" ]]; then
+        return 1
+    fi
+    plugin_data_set "uptime" "$(format_uptime_seconds "$uptime_seconds")"
 }
 
 plugin_render() {

--- a/src/plugins/weather.sh
+++ b/src/plugins/weather.sh
@@ -82,26 +82,26 @@ _resolve_format() {
     local format="$1"
 
     case "$format" in
-        compact)
-            # Compact: temperature and condition icon
-            printf '%s' '%t %c'
-            ;;
-        full)
-            # Full: temperature, condition icon, and humidity
-            printf '%s' '%t %c H:%h'
-            ;;
-        minimal)
-            # Minimal: just temperature
-            printf '%s' '%t'
-            ;;
-        detailed)
-            # Detailed: location, temperature, and condition icon
-            printf '%s' '%l: %t %c'
-            ;;
-        *)
-            # Custom format string - pass through as-is
-            printf '%s' "$format"
-            ;;
+    compact)
+        # Compact: temperature and condition icon
+        printf '%s' '%t %c'
+        ;;
+    full)
+        # Full: temperature, condition icon, and humidity
+        printf '%s' '%t %c H:%h'
+        ;;
+    minimal)
+        # Minimal: just temperature
+        printf '%s' '%t'
+        ;;
+    detailed)
+        # Detailed: location, temperature, and condition icon
+        printf '%s' '%l: %t %c'
+        ;;
+    *)
+        # Custom format string - pass through as-is
+        printf '%s' "$format"
+        ;;
     esac
 }
 
@@ -242,7 +242,10 @@ declare -gA _LANGUAGE_MAP=(
 # Output: mapped language code or "en" (English fallback)
 _map_language() {
     local lang="$1"
-    [[ -z "$lang" ]] && { printf 'en'; return; }
+    [[ -z "$lang" ]] && {
+        printf 'en'
+        return
+    }
 
     printf '%s' "${_LANGUAGE_MAP[$lang]:-en}"
 }
@@ -288,58 +291,58 @@ plugin_get_icon() {
 
 declare -gA _WMO_CODE_MAP=(
     # Clear/Sunny (0)
-    [0]=$'\U000F0599'                # nf-md-weather_sunny
+    [0]=$'\U000F0599' # nf-md-weather_sunny
 
     # Mainly clear (1)
-    [1]=$'\U000F0595'                # nf-md-weather_partly_cloudy
+    [1]=$'\U000F0595' # nf-md-weather_partly_cloudy
 
     # Partly cloudy (2)
-    [2]=$'\U000F0595'                # nf-md-weather_partly_cloudy
+    [2]=$'\U000F0595' # nf-md-weather_partly_cloudy
 
     # Overcast (3)
-    [3]=$'\U000F0590'                # nf-md-weather_cloudy
+    [3]=$'\U000F0590' # nf-md-weather_cloudy
 
     # Fog (45, 48)
-    [45]=$'\U000F0591'               # nf-md-weather_fog
-    [48]=$'\U000F0591'               # nf-md-weather_fog
+    [45]=$'\U000F0591' # nf-md-weather_fog
+    [48]=$'\U000F0591' # nf-md-weather_fog
 
     # Drizzle (light precipitation)
-    [51]=$'\U000F0597'               # nf-md-weather_rainy
-    [53]=$'\U000F0597'               # nf-md-weather_rainy
-    [55]=$'\U000F0597'               # nf-md-weather_rainy
+    [51]=$'\U000F0597' # nf-md-weather_rainy
+    [53]=$'\U000F0597' # nf-md-weather_rainy
+    [55]=$'\U000F0597' # nf-md-weather_rainy
 
     # Freezing drizzle
-    [56]=$'\U000F0598'               # nf-md-weather_snowy
-    [57]=$'\U000F0598'               # nf-md-weather_snowy
+    [56]=$'\U000F0598' # nf-md-weather_snowy
+    [57]=$'\U000F0598' # nf-md-weather_snowy
 
     # Rain (moderate)
-    [61]=$'\U000F0597'               # nf-md-weather_rainy
-    [63]=$'\U000F0597'               # nf-md-weather_rainy
-    [65]=$'\U000F0597'               # nf-md-weather_rainy
+    [61]=$'\U000F0597' # nf-md-weather_rainy
+    [63]=$'\U000F0597' # nf-md-weather_rainy
+    [65]=$'\U000F0597' # nf-md-weather_rainy
 
     # Freezing rain
-    [66]=$'\U000F0598'               # nf-md-weather_snowy
-    [67]=$'\U000F0598'               # nf-md-weather_snowy
+    [66]=$'\U000F0598' # nf-md-weather_snowy
+    [67]=$'\U000F0598' # nf-md-weather_snowy
 
     # Snow
-    [71]=$'\U000F0598'               # nf-md-weather_snowy
-    [73]=$'\U000F0598'               # nf-md-weather_snowy
-    [75]=$'\U000F0598'               # nf-md-weather_snowy
-    [77]=$'\U000F0598'               # nf-md-weather_snowy
+    [71]=$'\U000F0598' # nf-md-weather_snowy
+    [73]=$'\U000F0598' # nf-md-weather_snowy
+    [75]=$'\U000F0598' # nf-md-weather_snowy
+    [77]=$'\U000F0598' # nf-md-weather_snowy
 
     # Rain showers
-    [80]=$'\U000F0597'               # nf-md-weather_rainy
-    [81]=$'\U000F0597'               # nf-md-weather_rainy
-    [82]=$'\U000F0597'               # nf-md-weather_rainy
+    [80]=$'\U000F0597' # nf-md-weather_rainy
+    [81]=$'\U000F0597' # nf-md-weather_rainy
+    [82]=$'\U000F0597' # nf-md-weather_rainy
 
     # Snow showers
-    [85]=$'\U000F0598'               # nf-md-weather_snowy
-    [86]=$'\U000F0598'               # nf-md-weather_snowy
+    [85]=$'\U000F0598' # nf-md-weather_snowy
+    [86]=$'\U000F0598' # nf-md-weather_snowy
 
     # Thunderstorm
-    [95]=$'\U000F0596'               # nf-md-weather_lightning_rainy
-    [96]=$'\U000F0596'               # nf-md-weather_lightning_rainy
-    [99]=$'\U000F0596'               # nf-md-weather_lightning_rainy
+    [95]=$'\U000F0596' # nf-md-weather_lightning_rainy
+    [96]=$'\U000F0596' # nf-md-weather_lightning_rainy
+    [99]=$'\U000F0596' # nf-md-weather_lightning_rainy
 )
 
 declare -gA _WMO_CODE_TEXT=(
@@ -376,14 +379,23 @@ declare -gA _WMO_CODE_TEXT=(
 # Map WMO weather code to Nerd Font icon
 _map_weather_code() {
     local code="$1"
-    local is_day="${2:-1}"  # 1 for day, 0 for night
+    local is_day="${2:-1}" # 1 for day, 0 for night
 
     # Handle night variants for codes 0, 1, 2 (clear/cloudy conditions)
     if [[ "$is_day" -eq 0 ]]; then
         case "$code" in
-            0) printf '%s' $'\U000F0594'; return 0;;         # nf-md-weather_night (clear sky → night)
-            1) printf '%s' $'\U000F0594'; return 0;;         # nf-md-weather_night (mainly clear → night)
-            2) printf '%s' $'\U000F0594'; return 0;;         # nf-md-weather_night (partly cloudy → night)
+        0)
+            printf '%s' $'\U000F0594'
+            return 0
+            ;; # nf-md-weather_night (clear sky → night)
+        1)
+            printf '%s' $'\U000F0594'
+            return 0
+            ;; # nf-md-weather_night (mainly clear → night)
+        2)
+            printf '%s' $'\U000F0594'
+            return 0
+            ;; # nf-md-weather_night (partly cloudy → night)
         esac
     fi
 
@@ -391,7 +403,7 @@ _map_weather_code() {
     if [[ -n "${_WMO_CODE_MAP[$code]:-}" ]]; then
         printf '%s' "${_WMO_CODE_MAP[$code]}"
     else
-        printf '%s' $'\U000F0590'  # Fallback: generic cloudy icon
+        printf '%s' $'\U000F0590' # Fallback: generic cloudy icon
     fi
 }
 
@@ -501,8 +513,8 @@ _geocode_location() {
     if [[ -z "$location" ]]; then
         normalized=""
     else
-        normalized=$(printf '%s' "$location" | \
-            tr '[:upper:]' '[:lower:]' | \
+        normalized=$(printf '%s' "$location" |
+            tr '[:upper:]' '[:lower:]' |
             sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[[:space:]]/_/g')
     fi
 
@@ -540,8 +552,20 @@ _geocode_location() {
 # Rate Limiting Protection
 # =============================================================================
 
-# Check if rate limit has been exceeded for the current hour
-# Returns: 0 if request allowed, 1 if rate limited
+# Check if rate limit has been exceeded for the current hour.
+# Reserves a slot BEFORE the request and only consumes it after a
+# successful response. Failed requests release the reservation so the
+# real outbound-call count matches the counter instead of being
+# inflated by transport failures.
+#
+# Returns:
+#   0  → slot reserved; caller MUST call _release_rate_limit on failure
+#        or _consume_rate_limit on success
+#   1  → rate limited (do not call release/consume)
+#
+# Backward compatibility: legacy callers that only call
+# _check_rate_limit continue to work because the reservation is
+# persisted immediately. The release/consume helpers are opt-in.
 _check_rate_limit() {
     local max_per_hour
     max_per_hour=$(get_option "max_requests_per_hour")
@@ -550,20 +574,45 @@ _check_rate_limit() {
     local hour_bucket
     hour_bucket=$(date +"%Y%m%d%H")
     local cache_key="weather_rate_limit:${hour_bucket}"
+    local pending_key="weather_rate_pending:${hour_bucket}"
 
-    # Get current count for this hour (default to 0)
-    local current_count
+    local current_count pending_count effective
     current_count=$(cache_get "$cache_key" "3600") || current_count="0"
+    pending_count=$(cache_get "$pending_key" "120") || pending_count="0"
+    effective=$((current_count + pending_count))
 
     # Check if over limit
-    if (( current_count >= max_per_hour )); then
-        log_debug "weather" "Rate limit exceeded: ${current_count}/${max_per_hour}"
+    if ((effective >= max_per_hour)); then
+        log_debug "weather" "Rate limit exceeded: ${effective}/${max_per_hour}"
         return 1
     fi
 
-    # Increment counter and cache it
-    cache_set "$cache_key" "$((current_count + 1))"
+    # Reserve a slot. The reservation lives in a short-TTL cache so a
+    # crash mid-request still releases the slot within 2 minutes.
+    cache_set "$pending_key" "$((pending_count + 1))" "120"
+
+    # Also bump the persistent counter so the cap is observed even
+    # before the request returns. The release helper rolls it back if
+    # the request fails.
+    cache_set "$cache_key" "$((current_count + 1))" "3600"
     return 0
+}
+
+# Release a reserved slot after a failed outbound request. This avoids
+# inflating the per-hour counter with transport failures or 4xx/5xx
+# responses that did not actually hit the upstream quota.
+_release_rate_limit() {
+    local hour_bucket
+    hour_bucket=$(date +"%Y%m%d%H")
+    local cache_key="weather_rate_limit:${hour_bucket}"
+    local pending_key="weather_rate_pending:${hour_bucket}"
+
+    local current_count pending_count
+    current_count=$(cache_get "$cache_key" "3600") || current_count="0"
+    pending_count=$(cache_get "$pending_key" "120") || pending_count="0"
+
+    ((current_count > 0)) && cache_set "$cache_key" "$((current_count - 1))" "3600"
+    ((pending_count > 0)) && cache_set "$pending_key" "$((pending_count - 1))" "120"
 }
 
 # =============================================================================
@@ -644,7 +693,7 @@ _fetch_weather_openmeteo() {
 
     # Step 2: Parse geocode result
     local lat lon location_name
-    IFS='|' read -r lat lon location_name <<< "$geocode_result"
+    IFS='|' read -r lat lon location_name <<<"$geocode_result"
 
     [[ -z "$lat" || -z "$lon" ]] && return 1
 
@@ -653,20 +702,20 @@ _fetch_weather_openmeteo() {
     local wind_unit="kmh"
 
     case "$units" in
-        u)
-            temp_unit="fahrenheit"
-            wind_unit="mph"
-            ;;
-        M)
-            # SI units: Celsius and m/s (Note: Kelvin not supported by Open Meteo)
-            temp_unit="celsius"
-            wind_unit="ms"
-            ;;
-        *)
-            # Default: metric (Celsius, km/h)
-            temp_unit="celsius"
-            wind_unit="kmh"
-            ;;
+    u)
+        temp_unit="fahrenheit"
+        wind_unit="mph"
+        ;;
+    M)
+        # SI units: Celsius and m/s (Note: Kelvin not supported by Open Meteo)
+        temp_unit="celsius"
+        wind_unit="ms"
+        ;;
+    *)
+        # Default: metric (Celsius, km/h)
+        temp_unit="celsius"
+        wind_unit="kmh"
+        ;;
     esac
 
     # Step 4: Build API URL with current weather variables
@@ -719,12 +768,15 @@ _degrees_to_compass() {
     local degrees="$1"
 
     # Validate input
-    [[ ! "$degrees" =~ ^[0-9]+(\.[0-9]+)?$ ]] && { printf 'N'; return; }
+    [[ ! "$degrees" =~ ^[0-9]+(\.[0-9]+)?$ ]] && {
+        printf 'N'
+        return
+    }
 
     # 16-point compass: each direction covers 22.5 degrees
     # Formula: index = ((degrees + 11.25) / 22.5) % 16
     # Using integer math: index = ((degrees + 11) / 22) % 16
-    local index=$(( (${degrees%.*} + 11) / 22 % 16 ))
+    local index=$(((${degrees%.*} + 11) / 22 % 16))
 
     local compass_points=(
         "N" "NNE" "NE" "ENE" "E" "ESE" "SE" "SSE"
@@ -752,7 +804,7 @@ _parse_json_value() {
     # Fallback: regex parsing (fragile but better than nothing)
     # Convert dot notation to regex pattern
     # Example: "current.temperature_2m" -> match after "temperature_2m":<whitespace>value
-    local key="${key_path##*.}"  # Get last part after dot
+    local key="${key_path##*.}" # Get last part after dot
 
     # Match: "key": value (number) or "key": "value" (string)
     if [[ "$json" =~ \"$key\":[[:space:]]*([0-9.-]+) ]]; then
@@ -772,18 +824,18 @@ _resolve_format_openmeteo() {
 
     # Resolve preset formats first
     case "$format" in
-        compact)
-            format='%t %c'
-            ;;
-        full)
-            format='%t %c H:%h'
-            ;;
-        minimal)
-            format='%t'
-            ;;
-        detailed)
-            format='%l: %t %c'
-            ;;
+    compact)
+        format='%t %c'
+        ;;
+    full)
+        format='%t %c H:%h'
+        ;;
+    minimal)
+        format='%t'
+        ;;
+    detailed)
+        format='%l: %t %c'
+        ;;
     esac
 
     # Parse all needed values from JSON
@@ -846,8 +898,8 @@ _resolve_format_openmeteo() {
     result="${result//%h/${humidity}%}"
     result="${result//%l/$location_name}"
     result="${result//%p/${precipitation}mm}"
-    result="${result//%P/}"  # Empty - not available
-    result="${result//%m/}"  # Empty - not available
+    result="${result//%P/}" # Empty - not available
+    result="${result//%m/}" # Empty - not available
 
     # Clean up: remove empty placeholders and extra spaces
     result=$(printf '%s' "$result" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/[[:space:]]\{2,\}/ /g')
@@ -860,7 +912,9 @@ _resolve_format_openmeteo() {
 # =============================================================================
 
 plugin_collect() {
-    # Step 1: Check rate limiting first
+    # Step 1: Check rate limiting first. _check_rate_limit reserves a
+    # slot; on a failed fetch we release it so transport errors do not
+    # consume the per-hour quota.
     _check_rate_limit || {
         # Rate limited - try to use cached data
         local cached_weather
@@ -876,9 +930,13 @@ plugin_collect() {
         return 1
     }
 
-    # Step 2: Fetch weather from Open Meteo
+    # Step 2: Fetch weather from Open Meteo. On any failure, release
+    # the reserved slot so the counter reflects only real upstream calls.
     local result
-    result=$(_fetch_weather_openmeteo) || return 1
+    if ! result=$(_fetch_weather_openmeteo); then
+        _release_rate_limit
+        return 1
+    fi
 
     # Step 3: Parse pipe-separated result (json_data|location_name)
     local json_data="${result%|*}"

--- a/src/renderer/compositor.sh
+++ b/src/renderer/compositor.sh
@@ -43,7 +43,7 @@ _is_explicit_three_element_order() {
 
     # Count elements
     local -a parts
-    IFS=',' read -ra parts <<< "$order"
+    IFS=',' read -ra parts <<<"$order"
 
     # Must have exactly 3 elements for centered layout
     [[ ${#parts[@]} -eq 3 ]] && return 0
@@ -59,10 +59,13 @@ _is_explicit_three_element_order() {
 _expand_order() {
     local order="$1"
 
-    [[ "$order" == *"windows"* ]] && { printf '%s' "$order"; return; }
+    [[ "$order" == *"windows"* ]] && {
+        printf '%s' "$order"
+        return
+    }
 
     local -a parts
-    IFS=',' read -ra parts <<< "$order"
+    IFS=',' read -ra parts <<<"$order"
 
     if [[ ${#parts[@]} -ge 2 ]]; then
         local last_idx=$((${#parts[@]} - 1))
@@ -89,15 +92,15 @@ _render_entity() {
     local align="${3:-}"
 
     case "$entity" in
-        windows)
-            _get_windows_format "$side" "$align"
-            ;;
-        plugins)
-            plugins_render "$side"
-            ;;
-        *)
-            "${entity}_render" "$side"
-            ;;
+    windows)
+        _get_windows_format "$side" "$align"
+        ;;
+    plugins)
+        plugins_render "$side"
+        ;;
+    *)
+        "${entity}_render" "$side"
+        ;;
     esac
 }
 
@@ -111,7 +114,7 @@ _split_at_windows() {
     _AFTER_WINDOWS=()
 
     local -a entities
-    IFS=',' read -ra entities <<< "$order"
+    IFS=',' read -ra entities <<<"$order"
 
     local found_windows=0
     for entity in "${entities[@]}"; do
@@ -231,20 +234,20 @@ _get_windows_format_left_centered() {
     local fmt=""
     local status_bg active_bg inactive_bg sep_char transparent
 
-    transparent=$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")
+    printf -v transparent '%s' "$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")"
 
     # In transparent mode, hide edge separators
     if [[ "$transparent" == "true" ]]; then
-        status_bg=$(resolve_color "background")
+        printf -v status_bg '%s' "$(resolve_color "background")"
     else
-        status_bg=$(resolve_color "statusbar-bg")
+        printf -v status_bg '%s' "$(resolve_color "statusbar-bg")"
     fi
 
-    active_bg=$(resolve_color "window-active-base")
-    inactive_bg=$(resolve_color "window-inactive-base")
+    printf -v active_bg '%s' "$(resolve_color "window-active-base")"
+    printf -v inactive_bg '%s' "$(resolve_color "window-inactive-base")"
 
     # Edge separator glyph (right-pointing) - respects :all suffix
-    sep_char=$(get_edge_right_separator)
+    printf -v sep_char '%s' "$(get_edge_right_separator)"
 
     # === WINDOWS LIST (left-aligned, no entry separator) ===
     fmt+='#[list=on align=left]'
@@ -325,19 +328,19 @@ _get_windows_format_right_centered() {
     local fmt=""
     local status_bg transparent
 
-    transparent=$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")
+    printf -v transparent '%s' "$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")"
 
     # In transparent mode, hide edge separators
     if [[ "$transparent" == "true" ]]; then
-        status_bg=$(resolve_color "background")
+        printf -v status_bg '%s' "$(resolve_color "background")"
     else
-        status_bg=$(resolve_color "statusbar-bg")
+        printf -v status_bg '%s' "$(resolve_color "statusbar-bg")"
     fi
 
     # Index backgrounds (for entry separator - first window index)
     local active_index_bg inactive_index_bg
-    active_index_bg=$(resolve_color "window-active-base-lighter")
-    inactive_index_bg=$(resolve_color "window-inactive-base-lighter")
+    printf -v active_index_bg '%s' "$(resolve_color "window-active-base-lighter")"
+    printf -v inactive_index_bg '%s' "$(resolve_color "window-inactive-base-lighter")"
 
     # === ENTRY EDGE SEPARATOR ===
     # Left-pointing (◀) for right element - per rule: right element edge points LEFT
@@ -345,13 +348,13 @@ _get_windows_format_right_centered() {
     # Use #{base-index} to support both base-index=0 and base-index=1
     # Respect @powerkit_active_window_show_index and @powerkit_inactive_window_show_index
     local entry_sep_char show_index_active show_index_inactive
-    entry_sep_char=$(get_edge_left_separator)
-    show_index_active=$(get_tmux_option "@powerkit_active_window_show_index" "true")
-    show_index_inactive=$(get_tmux_option "@powerkit_inactive_window_show_index" "true")
+    printf -v entry_sep_char '%s' "$(get_edge_left_separator)"
+    printf -v show_index_active '%s' "$(get_tmux_option "@powerkit_active_window_show_index" "true")"
+    printf -v show_index_inactive '%s' "$(get_tmux_option "@powerkit_inactive_window_show_index" "true")"
 
     if [[ -n "$entry_sep_char" ]]; then
         local first_index_bg first_content_bg first_bg
-        first_content_bg=$(resolve_color "window-inactive-base")
+        printf -v first_content_bg '%s' "$(resolve_color "window-inactive-base")"
 
         # Determine which background to use based on show_index settings
         if [[ "$show_index_active" == "false" && "$show_index_inactive" == "false" ]]; then
@@ -418,23 +421,23 @@ _get_windows_format_centered() {
     local fmt=""
     local status_bg active_bg inactive_bg sep_char transparent
 
-    transparent=$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")
+    printf -v transparent '%s' "$(get_tmux_option "@powerkit_transparent" "${POWERKIT_DEFAULT_TRANSPARENT}")"
 
     # In transparent mode, hide edge separators
     if [[ "$transparent" == "true" ]]; then
-        status_bg=$(resolve_color "background")
+        printf -v status_bg '%s' "$(resolve_color "background")"
     else
-        status_bg=$(resolve_color "statusbar-bg")
+        printf -v status_bg '%s' "$(resolve_color "statusbar-bg")"
     fi
 
     # Content backgrounds (for exit separator - last window content)
-    active_bg=$(resolve_color "window-active-base")
-    inactive_bg=$(resolve_color "window-inactive-base")
+    printf -v active_bg '%s' "$(resolve_color "window-active-base")"
+    printf -v inactive_bg '%s' "$(resolve_color "window-inactive-base")"
 
     # Index backgrounds (for entry separator - first window index)
     local active_index_bg inactive_index_bg
-    active_index_bg=$(resolve_color "window-active-base-lighter")
-    inactive_index_bg=$(resolve_color "window-inactive-base-lighter")
+    printf -v active_index_bg '%s' "$(resolve_color "window-active-base-lighter")"
+    printf -v inactive_index_bg '%s' "$(resolve_color "window-inactive-base-lighter")"
 
     # === ENTRY EDGE SEPARATOR ===
     # Left-pointing (◀) for entry - receiving from left gap
@@ -442,13 +445,13 @@ _get_windows_format_centered() {
     # Use #{base-index} to support both base-index=0 and base-index=1
     # Respect @powerkit_active_window_show_index and @powerkit_inactive_window_show_index
     local entry_sep_char show_index_active show_index_inactive
-    entry_sep_char=$(get_edge_left_separator)
-    show_index_active=$(get_tmux_option "@powerkit_active_window_show_index" "true")
-    show_index_inactive=$(get_tmux_option "@powerkit_inactive_window_show_index" "true")
+    printf -v entry_sep_char '%s' "$(get_edge_left_separator)"
+    printf -v show_index_active '%s' "$(get_tmux_option "@powerkit_active_window_show_index" "true")"
+    printf -v show_index_inactive '%s' "$(get_tmux_option "@powerkit_inactive_window_show_index" "true")"
 
     if [[ -n "$entry_sep_char" ]]; then
         local first_index_bg first_content_bg first_bg
-        first_content_bg=$(resolve_color "window-inactive-base")
+        printf -v first_content_bg '%s' "$(resolve_color "window-inactive-base")"
 
         # Determine which background to use based on show_index settings
         if [[ "$show_index_active" == "false" && "$show_index_inactive" == "false" ]]; then
@@ -757,12 +760,12 @@ _compose_line() {
     local side="${2:-left}"
 
     local -a entities
-    IFS=',' read -ra entities <<< "$order"
+    IFS=',' read -ra entities <<<"$order"
 
     local result="" prev_entity=""
 
     for entity in "${entities[@]}"; do
-        entity="${entity// /}"  # trim whitespace
+        entity="${entity// /}" # trim whitespace
 
         # Add separator BETWEEN entities (not before first)
         [[ -n "$prev_entity" ]] && result+=$(_build_inter_entity_separator "$prev_entity" "$entity" "$side")
@@ -836,7 +839,7 @@ _apply_single_standard() {
     local left_content=""
     if [[ ${#_BEFORE_WINDOWS[@]} -gt 0 ]]; then
         local first_left="${_BEFORE_WINDOWS[0]}"
-        local last_left="${_BEFORE_WINDOWS[${#_BEFORE_WINDOWS[@]}-1]}"
+        local last_left="${_BEFORE_WINDOWS[${#_BEFORE_WINDOWS[@]} - 1]}"
 
         # Add entry edge separator for first entity when :all suffix is enabled
         if [[ "$apply_all_edges" == "true" ]]; then
@@ -844,7 +847,10 @@ _apply_single_standard() {
         fi
 
         local left_order
-        left_order=$(IFS=','; echo "${_BEFORE_WINDOWS[*]}")
+        left_order=$(
+            IFS=','
+            echo "${_BEFORE_WINDOWS[*]}"
+        )
         left_content+=$(_compose_line "$left_order" "left")
 
         if [[ "$window_spacing_enabled" == "true" ]]; then
@@ -888,11 +894,14 @@ _apply_single_standard() {
         local first_right="${_AFTER_WINDOWS[0]}"
 
         # Plugins handle their own initial separator
-        [[ "$first_right" != "plugins" ]] && \
+        [[ "$first_right" != "plugins" ]] &&
             right_content+=$(_build_inter_entity_separator "windows" "$first_right" "right")
 
         local right_order
-        right_order=$(IFS=','; echo "${_AFTER_WINDOWS[*]}")
+        right_order=$(
+            IFS=','
+            echo "${_AFTER_WINDOWS[*]}"
+        )
         right_content+=$(_compose_line "$right_order" "right")
     fi
 
@@ -923,10 +932,13 @@ _apply_single_inverted() {
     local left_content=""
     if [[ ${#_BEFORE_WINDOWS[@]} -gt 0 ]]; then
         local left_order
-        left_order=$(IFS=','; echo "${_BEFORE_WINDOWS[*]}")
+        left_order=$(
+            IFS=','
+            echo "${_BEFORE_WINDOWS[*]}"
+        )
         left_content=$(_compose_line "$left_order" "left")
 
-        local last_left="${_BEFORE_WINDOWS[${#_BEFORE_WINDOWS[@]}-1]}"
+        local last_left="${_BEFORE_WINDOWS[${#_BEFORE_WINDOWS[@]} - 1]}"
         left_content+=$(_build_edge_separator "$last_left" "end" "left")
     fi
 
@@ -991,7 +1003,7 @@ _apply_single_inverted() {
 _apply_single_centered() {
     local order="$1"
     local -a entities
-    IFS=',' read -ra entities <<< "$order"
+    IFS=',' read -ra entities <<<"$order"
 
     # With exactly 3 elements, positions are clear
     local left_entity="${entities[0]}"
@@ -1089,7 +1101,7 @@ _apply_double_layout() {
     status_bg=$(resolve_color "statusbar-bg")
 
     local -a entities
-    IFS=',' read -ra entities <<< "$order"
+    IFS=',' read -ra entities <<<"$order"
 
     # Split entities into line0 and line1
     local first_entity="${entities[0]}"
@@ -1198,9 +1210,9 @@ _build_line_content() {
     # Add edge separator at end (only for left-aligned line 0)
     if [[ "$side" == "left" && -n "$last_entity" ]]; then
         case "$last_entity" in
-            windows) content+=$(_build_left_edge_separator) ;;
-            plugins) ;; # Plugins add their own
-            *) content+=$(_build_edge_separator "$last_entity" "end" "left") ;;
+        windows) content+=$(_build_left_edge_separator) ;;
+        plugins) ;; # Plugins add their own
+        *) content+=$(_build_edge_separator "$last_entity" "end" "left") ;;
         esac
     fi
 

--- a/src/renderer/segment_builder.sh
+++ b/src/renderer/segment_builder.sh
@@ -106,24 +106,38 @@ _get_icon_padding() {
 #            {content}, {content_bg}, {content_fg}, {prev_bg}, {next_bg}
 declare -g DEFAULT_SEGMENT_TEMPLATE='{sep_left}{icon_section}{sep_internal}{content_section}{sep_right}'
 
-# Get global or plugin-specific template
+# Per-cycle template cache (Sprint 2.6). Templates don't change mid-cycle, so
+# we cache both the global template and any plugin-specific templates.
+declare -gA _TEMPLATE_CACHE=()
+
+# Get global or plugin-specific template (cycle-cached).
 # Usage: get_segment_template ["plugin_name"]
 # shellcheck disable=SC2120  # Function designed to be called with or without arguments
 get_segment_template() {
     local plugin="${1:-}"
+    local cache_key="${plugin:-__global__}"
 
+    # Hit cache if populated this cycle.
+    if [[ -n "${_TEMPLATE_CACHE[$cache_key]:-}" ]]; then
+        printf '%s' "${_TEMPLATE_CACHE[$cache_key]}"
+        return 0
+    fi
+
+    local template=""
     # Try plugin-specific template first
     if [[ -n "$plugin" ]]; then
-        local plugin_template
-        plugin_template=$(get_tmux_option "@powerkit_plugin_${plugin}_template" "")
-        [[ -n "$plugin_template" ]] && {
-            printf '%s' "$plugin_template"
-            return
-        }
+        printf -v template '%s' "$(get_tmux_option "@powerkit_plugin_${plugin}_template" "")"
+        if [[ -n "$template" ]]; then
+            _TEMPLATE_CACHE["$cache_key"]="$template"
+            printf '%s' "$template"
+            return 0
+        fi
     fi
 
     # Fall back to global template
-    get_tmux_option "@powerkit_segment_template" "$DEFAULT_SEGMENT_TEMPLATE"
+    printf -v template '%s' "$(get_tmux_option "@powerkit_segment_template" "$DEFAULT_SEGMENT_TEMPLATE")"
+    _TEMPLATE_CACHE["$cache_key"]="$template"
+    printf '%s' "$template"
 }
 
 # =============================================================================

--- a/src/renderer/separator.sh
+++ b/src/renderer/separator.sh
@@ -29,6 +29,11 @@ declare -g _SEP_CACHE_EDGE_STYLE=""
 declare -g _SEP_CACHE_EDGE_APPLY_ALL=""
 declare -g _SEP_CACHE_INITIAL_STYLE=""
 declare -g _SEP_CACHE_LEFT=""
+
+# Per-cycle build cache for (prev_bg, next_bg) → formatted tmux separator
+# (Sprint 2.9). Avoids re-emitting the same #[fg=...]/#[bg=...] tmux format
+# string on every render for the same color tuple.
+declare -gA _SEP_BUILD_CACHE=()
 declare -g _SEP_CACHE_RIGHT=""
 declare -g _SEP_CACHE_INITIAL=""
 declare -g _SEP_CACHE_FINAL=""
@@ -48,6 +53,7 @@ separator_reset_cache() {
     _SEP_CACHE_FINAL=""
     _SEP_CACHE_SPACING_MODE=""
     _SEP_CACHE_EDGE_LEFT=""
+    _SEP_BUILD_CACHE=()
     _SEP_CACHE_EDGE_RIGHT=""
 }
 
@@ -159,29 +165,29 @@ _get_separator_glyph() {
 
     if [[ "$direction" == "left" ]]; then
         case "$style" in
-            normal)           printf '%s' "$POWERKIT_SEP_SOLID_LEFT" ;;
-            rounded)          printf '%s' "$POWERKIT_SEP_ROUND_LEFT" ;;
-            slant)            printf '%s' "$POWERKIT_SEP_SLANT_LEFT" ;;
-            slantup|slant-up) printf '%s' "$POWERKIT_SEP_SLANT_UP_LEFT" ;;
-            flame)            printf '%s' "$POWERKIT_SEP_FLAME_LEFT" ;;
-            pixel)            printf '%s' "$POWERKIT_SEP_PIXEL_LEFT" ;;
-            honeycomb)        printf '%s' "$POWERKIT_SEP_HONEYCOMB_LEFT" ;;
-            trapezoid)        printf '%s' "$POWERKIT_SEP_TRAPEZOID_LEFT" ;;
-            none)             printf '' ;;
-            *)                printf '%s' "$POWERKIT_SEP_ROUND_LEFT" ;;
+        normal) printf '%s' "$POWERKIT_SEP_SOLID_LEFT" ;;
+        rounded) printf '%s' "$POWERKIT_SEP_ROUND_LEFT" ;;
+        slant) printf '%s' "$POWERKIT_SEP_SLANT_LEFT" ;;
+        slantup | slant-up) printf '%s' "$POWERKIT_SEP_SLANT_UP_LEFT" ;;
+        flame) printf '%s' "$POWERKIT_SEP_FLAME_LEFT" ;;
+        pixel) printf '%s' "$POWERKIT_SEP_PIXEL_LEFT" ;;
+        honeycomb) printf '%s' "$POWERKIT_SEP_HONEYCOMB_LEFT" ;;
+        trapezoid) printf '%s' "$POWERKIT_SEP_TRAPEZOID_LEFT" ;;
+        none) printf '' ;;
+        *) printf '%s' "$POWERKIT_SEP_ROUND_LEFT" ;;
         esac
     else
         case "$style" in
-            normal)           printf '%s' "$POWERKIT_SEP_SOLID_RIGHT" ;;
-            rounded)          printf '%s' "$POWERKIT_SEP_ROUND_RIGHT" ;;
-            slant)            printf '%s' "$POWERKIT_SEP_SLANT_RIGHT" ;;
-            slantup|slant-up) printf '%s' "$POWERKIT_SEP_SLANT_UP_RIGHT" ;;
-            flame)            printf '%s' "$POWERKIT_SEP_FLAME_RIGHT" ;;
-            pixel)            printf '%s' "$POWERKIT_SEP_PIXEL_RIGHT" ;;
-            honeycomb)        printf '%s' "$POWERKIT_SEP_HONEYCOMB_RIGHT" ;;
-            trapezoid)        printf '%s' "$POWERKIT_SEP_TRAPEZOID_RIGHT" ;;
-            none)             printf '' ;;
-            *)                printf '%s' "$POWERKIT_SEP_ROUND_RIGHT" ;;
+        normal) printf '%s' "$POWERKIT_SEP_SOLID_RIGHT" ;;
+        rounded) printf '%s' "$POWERKIT_SEP_ROUND_RIGHT" ;;
+        slant) printf '%s' "$POWERKIT_SEP_SLANT_RIGHT" ;;
+        slantup | slant-up) printf '%s' "$POWERKIT_SEP_SLANT_UP_RIGHT" ;;
+        flame) printf '%s' "$POWERKIT_SEP_FLAME_RIGHT" ;;
+        pixel) printf '%s' "$POWERKIT_SEP_PIXEL_RIGHT" ;;
+        honeycomb) printf '%s' "$POWERKIT_SEP_HONEYCOMB_RIGHT" ;;
+        trapezoid) printf '%s' "$POWERKIT_SEP_TRAPEZOID_RIGHT" ;;
+        none) printf '' ;;
+        *) printf '%s' "$POWERKIT_SEP_ROUND_RIGHT" ;;
         esac
     fi
 }
@@ -297,12 +303,22 @@ build_right_separator() {
     local prev_bg="$1"
     local next_bg="$2"
 
+    local cache_key="r:${prev_bg}|${next_bg}"
+    local cached="${_SEP_BUILD_CACHE[$cache_key]:-}"
+    if [[ -n "$cached" ]]; then
+        printf '%s' "$cached"
+        return
+    fi
+
     local sep
     sep=$(get_right_separator)
 
     [[ -z "$sep" ]] && return
 
-    printf '#[fg=%s,bg=%s]%s' "$prev_bg" "$next_bg" "$sep"
+    local result
+    result=$(printf '#[fg=%s,bg=%s]%s' "$prev_bg" "$next_bg" "$sep")
+    _SEP_BUILD_CACHE["$cache_key"]="$result"
+    printf '%s' "$result"
 }
 
 # Build a LEFT-facing separator (◀) - used for status-right (plugins)
@@ -312,13 +328,23 @@ build_left_separator() {
     local prev_bg="$1"
     local next_bg="$2"
 
+    local cache_key="l:${prev_bg}|${next_bg}"
+    local cached="${_SEP_BUILD_CACHE[$cache_key]:-}"
+    if [[ -n "$cached" ]]; then
+        printf '%s' "$cached"
+        return
+    fi
+
     local sep
     sep=$(get_left_separator)
 
     [[ -z "$sep" ]] && return
 
     # For left-facing: fg=next (where arrow points), bg=previous (where we are)
-    printf '#[fg=%s,bg=%s]%s' "$next_bg" "$prev_bg" "$sep"
+    local result
+    result=$(printf '#[fg=%s,bg=%s]%s' "$next_bg" "$prev_bg" "$sep")
+    _SEP_BUILD_CACHE["$cache_key"]="$result"
+    printf '%s' "$result"
 }
 
 # =============================================================================
@@ -448,7 +474,7 @@ list_separator_styles() {
 is_valid_separator_style() {
     local style="$1"
     case "$style" in
-        normal|rounded|slant|slantup|slant-up|trapezoid|flame|pixel|honeycomb|none) return 0 ;;
-        *) return 1 ;;
+    normal | rounded | slant | slantup | slant-up | trapezoid | flame | pixel | honeycomb | none) return 0 ;;
+    *) return 1 ;;
     esac
 }

--- a/src/utils/api.sh
+++ b/src/utils/api.sh
@@ -107,6 +107,53 @@ make_api_call() {
 }
 
 # =============================================================================
+# Credential-Safe Transport
+# =============================================================================
+# These helpers avoid exposing secrets in process argv (visible via /proc,
+# ps, process accounting, set -x traces). Prefer them over make_api_call when
+# the credential would otherwise appear as a curl argv element.
+
+# Fetch a URL with an HTTP header passed via curl --config (stdin).
+# Usage: api_fetch_with_header_stdin "url" "Header-Name: value" [timeout]
+# Returns: response body; empty string on transport failure
+api_fetch_with_header_stdin() {
+    local url="$1" header="$2" timeout="${3:-5}"
+    printf 'header = "%s"\n' "$header" |
+        curl -sf --config - --connect-timeout "$timeout" --max-time "$((timeout * 2))" \
+            "$url" 2>/dev/null
+}
+
+# Fetch a URL with HTTP basic auth passed via a curl config file.
+# Usage: api_fetch_with_basic_config "url" "user" "password" [timeout]
+# Returns: response body; empty string on transport failure
+# The temp file is created with mode 600 and removed via trap on return.
+api_fetch_with_basic_config() {
+    local url="$1" user="$2" password="$3" timeout="${4:-5}"
+    local cfg
+    cfg=$(mktemp "${TMPDIR:-/tmp}/powerkit-curl.XXXXXX") || return 1
+    chmod 600 "$cfg"
+    trap 'rm -f "$cfg"' RETURN
+    printf -- '-u %s:%s\n' "$user" "$password" >"$cfg"
+    curl -sf --config "$cfg" --connect-timeout "$timeout" --max-time "$((timeout * 2))" \
+        "$url" 2>/dev/null
+}
+
+# Fetch a URL with bearer token in Authorization header, passed via stdin.
+# Usage: api_fetch_with_bearer "url" "token" [timeout]
+api_fetch_with_bearer() {
+    local url="$1" token="$2" timeout="${3:-5}"
+    api_fetch_with_header_stdin "$url" "Authorization: Bearer ${token}" "$timeout"
+}
+
+# Fetch a URL with a vendor-specific token header via stdin.
+# Usage: api_fetch_with_token_header "url" "Header-Name" "token" [timeout]
+# Example: api_fetch_with_token_header "$url" "PRIVATE-TOKEN" "$glpat" 5
+api_fetch_with_token_header() {
+    local url="$1" header_name="$2" token="$3" timeout="${4:-5}"
+    api_fetch_with_header_stdin "$url" "${header_name}: ${token}" "$timeout"
+}
+
+# =============================================================================
 # Response Validation
 # =============================================================================
 
@@ -126,6 +173,53 @@ api_validate_response() {
     [[ "$response" =~ \"error\" ]] && return 1
 
     return 0
+}
+
+# Validate that a string is parseable JSON (requires jq).
+# Usage: api_validate_json "$body" || return 1
+# Returns: 0 if valid JSON, 1 if not
+api_validate_json() {
+    local body="$1"
+    has_cmd jq || return 1
+    printf '%s' "$body" | jq -e . >/dev/null 2>&1
+}
+
+# Validate that a string is an IPv4 or IPv6 address.
+# Usage: api_validate_ip "$value" || return 1
+# Returns: 0 if valid IP, 1 if not
+api_validate_ip() {
+    local value="$1"
+    if [[ "$value" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+        local o
+        local IFS='.'
+        # shellcheck disable=SC2206
+        local -a octets=($value)
+        for o in "${octets[@]}"; do
+            ((o >= 0 && o <= 255)) || return 1
+        done
+        return 0
+    fi
+    [[ "$value" =~ ^[0-9a-fA-F:]+$ ]] && [[ "$value" == *:* ]]
+}
+
+# Classify an HTTP response into a canonical outcome string.
+# Usage: outcome=$(api_classify_outcome "$http_status" "$body")
+# Returns: success | unauthorized | forbidden | rate_limited | not_found |
+#          server_error | transport_error | malformed
+api_classify_outcome() {
+    local status="$1" body="${2:-}"
+    case "$status" in
+    2*) printf 'success' ;;
+    401) printf 'unauthorized' ;;
+    403) printf 'forbidden' ;;
+    404) printf 'not_found' ;;
+    429) printf 'rate_limited' ;;
+    5*) printf 'server_error' ;;
+    0 | "") printf 'transport_error' ;;
+    *)
+        [[ -z "$body" ]] && printf 'transport_error' || printf 'malformed'
+        ;;
+    esac
 }
 
 # Check if response contains specific error patterns

--- a/src/utils/api.sh
+++ b/src/utils/api.sh
@@ -72,6 +72,12 @@ api_fetch_with_auth() {
 # Make API call with supported authentication types.
 # Usage: make_api_call "url" "auth_type" "credential" [timeout]
 # auth_type: bearer, github, private-token, basic, or a legacy provider name.
+#
+# DEPRECATED: the credential is passed as a curl argv element and is
+# therefore visible in process listings. Prefer
+# api_fetch_with_bearer / api_fetch_with_token_header /
+# api_fetch_with_basic_config for any new caller so the secret stays
+# out of argv.
 make_api_call() {
     local url="$1"
     local auth_type="$2"
@@ -199,7 +205,36 @@ api_validate_ip() {
         done
         return 0
     fi
-    [[ "$value" =~ ^[0-9a-fA-F:]+$ ]] && [[ "$value" == *:* ]]
+    # IPv6: every group is 1-4 hex digits separated by ":". A single
+    # "::" is allowed to compress one or more zero groups. Reject
+    # values that have no colon at all, more than one "::", or that
+    # don't expose either the 8-group form or the compressed form.
+    if [[ ! "$value" =~ ^[0-9a-fA-F:]+$ ]]; then
+        return 1
+    fi
+    [[ "$value" == *:* ]] || return 1
+    # More than one "::" is invalid. awk splits on the literal "::"
+    # and reports the number of resulting fields; 1 means no "::",
+    # 2 means exactly one, 3+ means too many.
+    local dbl_colon_count
+    dbl_colon_count=$(awk -v v="$value" 'BEGIN { n = split(v, parts, "::"); print (n - 1) }')
+    [[ "$dbl_colon_count" -le 1 ]] || return 1
+    # Each non-empty group must be 1-4 hex digits; the empty groups
+    # around "::" are accepted as-is.
+    local IFS=':'
+    # shellcheck disable=SC2206
+    local -a groups=($value)
+    local g
+    for g in "${groups[@]}"; do
+        [[ -z "$g" || "$g" =~ ^[0-9a-fA-F]{1,4}$ ]] || return 1
+    done
+    # Require either 8 groups (full form) or at least one "::"
+    # (compressed form). Without this check "abc:def" would pass
+    # because both groups are valid 1-4 hex chunks.
+    if [[ "$value" == *"::"* ]]; then
+        return 0
+    fi
+    [[ "${#groups[@]}" -eq 8 ]]
 }
 
 # Classify an HTTP response into a canonical outcome string.

--- a/src/utils/api.sh
+++ b/src/utils/api.sh
@@ -55,13 +55,17 @@ api_fetch_with_retry() {
 # API fetch with authorization header
 # Usage: api_fetch_with_auth "https://api.example.com/endpoint" "Bearer token" [timeout]
 # Returns: Response body or empty string on failure
+#
+# The auth string is routed via curl --config (stdin) so the token never
+# appears in process argv.
 api_fetch_with_auth() {
     local url="$1"
     local auth="$2"
     local timeout="${3:-5}"
 
-    curl -s --connect-timeout "$timeout" --max-time "$timeout" \
-        -H "Authorization: $auth" \
+    printf 'header = "Authorization: %s"\n' "$auth" | curl -s \
+        --config - \
+        --connect-timeout "$timeout" --max-time "$timeout" \
         "$url" 2>/dev/null
 }
 
@@ -84,31 +88,37 @@ make_api_call() {
     local credential="$3"
     local timeout="${4:-5}"
 
-    local -a auth_args=()
-    local accept_header="Accept: application/json"
+    # Route every credential through curl --config (stdin) so the
+    # token never appears in process argv. The config body is built
+    # line by line depending on auth_type.
+    local cfg_body="" accept_header="Accept: application/json"
 
     case "$auth_type" in
     github)
-        auth_args=(-H "Authorization: token ${credential}")
+        cfg_body+="header = \"Authorization: token ${credential}\""$'\n'
         accept_header="Accept: application/vnd.github+json"
         ;;
     gitlab | private-token)
-        auth_args=(-H "PRIVATE-TOKEN: ${credential}")
+        cfg_body+="header = \"PRIVATE-TOKEN: ${credential}\""$'\n'
         ;;
     bitbucket | bearer)
-        auth_args=(-H "Authorization: Bearer ${credential}")
+        cfg_body+="header = \"Authorization: Bearer ${credential}\""$'\n'
         ;;
     basic)
-        auth_args=(-u "$credential")
+        cfg_body+="user = \"${credential}\""$'\n'
         ;;
     *)
-        [[ -n "$credential" ]] && auth_args=(-H "Authorization: Bearer ${credential}")
+        if [[ -n "$credential" ]]; then
+            cfg_body+="header = \"Authorization: Bearer ${credential}\""$'\n'
+        fi
         ;;
     esac
+    cfg_body+="header = \"${accept_header}\""$'\n'
 
-    curl -sf --connect-timeout "$timeout" --max-time "$((timeout * 2))" \
-        "${auth_args[@]}" \
-        -H "$accept_header" \
+    printf '%s' "$cfg_body" | curl -sf \
+        --config - \
+        --connect-timeout "$timeout" \
+        --max-time "$((timeout * 2))" \
         "$url" 2>/dev/null
 }
 

--- a/src/utils/network.sh
+++ b/src/utils/network.sh
@@ -39,30 +39,30 @@ safe_curl() {
 # Usage: make_api_call <url> <auth_type> <token> [timeout]
 # auth_type: "bearer" (standard OAuth), "github" (GitHub), "private-token" (GitLab), "basic" (user:pass)
 # Returns: API response or empty on error
+#
+# Every credential is routed through curl --config (stdin) so it never
+# appears in process argv. The Accept header stays in argv because it
+# is not a secret.
 _network_make_api_call() {
     local url="$1"
     local auth_type="$2"
     local token="$3"
     local timeout="${4:-5}"
 
-    local auth_args=()
+    local cfg_body=""
     if [[ -n "$token" ]]; then
         case "$auth_type" in
         bearer)
-            # Standard OAuth Bearer token (Bitbucket, etc.)
-            auth_args=(-H "Authorization: Bearer $token")
+            cfg_body+="header = \"Authorization: Bearer ${token}\""$'\n'
             ;;
         github)
-            # GitHub uses "token" instead of "Bearer"
-            auth_args=(-H "Authorization: token $token")
+            cfg_body+="header = \"Authorization: token ${token}\""$'\n'
             ;;
         private-token)
-            # GitLab style
-            auth_args=(-H "PRIVATE-TOKEN: $token")
+            cfg_body+="header = \"PRIVATE-TOKEN: ${token}\""$'\n'
             ;;
         basic)
-            # Basic auth (user:password or user:token)
-            auth_args=(-u "$token")
+            cfg_body+="user = \"${token}\""$'\n'
             ;;
         *)
             # No auth or unknown type
@@ -70,11 +70,18 @@ _network_make_api_call() {
         esac
     fi
 
-    curl -sf \
-        --connect-timeout "$timeout" \
-        --max-time "$((timeout * 2))" \
-        "${auth_args[@]}" \
-        "$url" 2>/dev/null
+    if [[ -z "$cfg_body" ]]; then
+        curl -sf \
+            --connect-timeout "$timeout" \
+            --max-time "$((timeout * 2))" \
+            "$url" 2>/dev/null
+    else
+        printf '%s' "$cfg_body" | curl -sf \
+            --config - \
+            --connect-timeout "$timeout" \
+            --max-time "$((timeout * 2))" \
+            "$url" 2>/dev/null
+    fi
 }
 
 # api.sh owns the canonical implementation when both utility modules are loaded.
@@ -84,6 +91,29 @@ if ! declare -F make_api_call &>/dev/null; then
         _network_make_api_call "$@"
     }
 fi
+
+# Credential-safe wrapper for callers that need HTTP Basic auth with an
+# email:token (or user:pass) pair. The Basic auth header is composed and
+# piped through stdin so neither the cleartext pair nor the base64 blob
+# ever appears in process argv.
+# Usage: safe_curl_with_auth "user:pass" "url" [timeout] [extra_argv...]
+safe_curl_with_auth() {
+    local userpass="$1"
+    local url="$2"
+    local timeout="${3:-5}"
+    shift 3 2>/dev/null || shift 2
+    local -a extra_args=("$@")
+    local auth_header
+    auth_header=$(printf '%s' "$userpass" | base64 | tr -d '\n')
+    {
+        printf 'header = "Authorization: Basic %s"\n' "$auth_header"
+    } | curl -sf \
+        --config - \
+        --connect-timeout "$timeout" \
+        --max-time "$((timeout * 2))" \
+        "${extra_args[@]}" \
+        "$url" 2>/dev/null
+}
 
 # =============================================================================
 # Endpoint Reachability

--- a/src/utils/numbers.sh
+++ b/src/utils/numbers.sh
@@ -54,7 +54,77 @@ extract_all_numbers() {
         input="${input#*${BASH_REMATCH[1]}}"
     done
 
-    printf '%s' "${numbers% }"  # Trim trailing space
+    printf '%s' "${numbers% }" # Trim trailing space
+}
+
+# =============================================================================
+# Internal: Pure-bash float formatter
+# =============================================================================
+# Formats a decimal value to N decimal places WITHOUT spawning awk.
+# Splits the value on '.', computes the rounded result using integer math,
+# and emits the formatted output.
+#
+# Usage: _format_float <value> <precision>
+#   value      - Decimal or integer string (may be negative)
+#   precision  - Number of decimal digits (>=0)
+#
+# Algorithm: scale value by 10^precision, round to nearest, split int/frac,
+# emit int.frac. Avoids any external process.
+_format_float() {
+    local value="$1"
+    local precision="$2"
+
+    local sign="" int_part frac_part
+    if [[ "$value" == -* ]]; then
+        sign="-"
+        value="${value#-}"
+    fi
+
+    int_part="${value%%.*}"
+    int_part="${int_part:-0}"
+    frac_part="${value#*.}"
+    [[ "$frac_part" == "$value" ]] && frac_part=""
+    frac_part="${frac_part:-0}"
+
+    # Pad/truncate frac_part to exactly $precision digits for rounding.
+    local i
+    while ((${#frac_part} < precision)); do
+        frac_part="${frac_part}0"
+    done
+    if ((${#frac_part} > precision)); then
+        # Keep one extra digit for rounding; drop the rest.
+        local extra="${frac_part:$precision:1}"
+        frac_part="${frac_part:0:$precision}"
+        if ((extra >= 5)); then
+            # Round up the last kept digit.
+            local carry=1
+            local j=$((precision - 1))
+            local rounded
+            while ((j >= 0)); do
+                local d="${frac_part:$j:1}"
+                local nd=$((d + carry))
+                if ((nd >= 10)); then
+                    nd=0
+                    carry=1
+                else
+                    carry=0
+                fi
+                rounded="${nd}${rounded:-}"
+                j=$((j - 1))
+            done
+            if ((carry)); then
+                int_part=$((int_part + 1))
+                rounded=""
+            fi
+            frac_part="$rounded"
+        fi
+    fi
+
+    if ((precision == 0)); then
+        printf '%s%d' "$sign" "$int_part"
+    else
+        printf '%s%d.%s' "$sign" "$int_part" "$frac_part"
+    fi
 }
 
 # =============================================================================
@@ -93,51 +163,138 @@ format_number() {
     fi
 }
 
-# Format bytes to human readable
+# Format bytes to human readable (pure bash, precision in {0,1,2}).
+# For precision > 2, fall back to awk (rare in practice).
 # Usage: format_bytes 1073741824  # Returns "1.0G"
 format_bytes() {
     local bytes="$1"
     local precision="${2:-1}"
 
-    if (( bytes >= POWERKIT_BYTE_TB )); then
-        awk -v b="$bytes" -v p="$precision" 'BEGIN { printf "%.*fT", p, b / 1099511627776 }'
-    elif (( bytes >= POWERKIT_BYTE_GB )); then
-        awk -v b="$bytes" -v p="$precision" 'BEGIN { printf "%.*fG", p, b / 1073741824 }'
-    elif (( bytes >= POWERKIT_BYTE_MB )); then
-        awk -v b="$bytes" -v p="$precision" 'BEGIN { printf "%.*fM", p, b / 1048576 }'
-    elif (( bytes >= POWERKIT_BYTE_KB )); then
-        awk -v b="$bytes" -v p="$precision" 'BEGIN { printf "%.*fK", p, b / 1024 }'
+    if ((precision > 2)); then
+        # Fallback for unusual precision; preserves original behavior.
+        awk -v b="$bytes" -v p="$precision" '
+            BEGIN {
+                if (b >= 1099511627776) printf "%.*fT", p, b / 1099511627776
+                else if (b >= 1073741824) printf "%.*fG", p, b / 1073741824
+                else if (b >= 1048576) printf "%.*fM", p, b / 1048576
+                else if (b >= 1024) printf "%.*fK", p, b / 1024
+                else printf "%dB", b
+            }'
+        return
+    fi
+
+    if ((bytes >= POWERKIT_BYTE_TB)); then
+        _format_byte_scaled "$bytes" "$POWERKIT_BYTE_TB" "$precision" "T"
+    elif ((bytes >= POWERKIT_BYTE_GB)); then
+        _format_byte_scaled "$bytes" "$POWERKIT_BYTE_GB" "$precision" "G"
+    elif ((bytes >= POWERKIT_BYTE_MB)); then
+        _format_byte_scaled "$bytes" "$POWERKIT_BYTE_MB" "$precision" "M"
+    elif ((bytes >= POWERKIT_BYTE_KB)); then
+        _format_byte_scaled "$bytes" "$POWERKIT_BYTE_KB" "$precision" "K"
     else
         printf '%dB' "$bytes"
     fi
 }
 
-# Format number to human readable with SI suffixes (base 1000)
+# Internal: render scaled bytes with N decimals + suffix.
+# Pure bash for precision in {0,1,2}; uses int/frac decomposition.
+_format_byte_scaled() {
+    local bytes="$1" divisor="$2" precision="$3" suffix="$4"
+    local int_part=$((bytes / divisor))
+    local frac=$(((bytes % divisor) * 100 / divisor)) # 2-decimal residual
+
+    if ((precision == 0)); then
+        printf '%d%s' "$int_part" "$suffix"
+        return
+    fi
+
+    # Round frac to "precision" decimals.
+    local carry=0
+    if ((precision == 1)); then
+        # Look at the second decimal: round up if >=5.
+        local second=$(((bytes % divisor) * 100 % divisor * 10 / divisor))
+        ((second >= 5)) && carry=1
+        frac=$(((bytes % divisor) * 10 / divisor)) # 1-decimal frac
+    fi
+    int_part=$((int_part + carry))
+
+    printf '%d.' "$int_part"
+    if ((precision == 1)); then
+        printf '%d' "$frac"
+    elif ((precision == 2)); then
+        printf '%02d' "$frac"
+    fi
+    printf '%s' "$suffix"
+}
+
+# Internal: render scaled bytes with N decimals + suffix.
+# Usage: _format_byte_scaled <bytes> <divisor> <precision> <suffix>
+# Avoids multiplication overflow by scaling in chunks when bytes is huge.
+_format_byte_scaled() {
+    local bytes="$1" divisor="$2" precision="$3" suffix="$4"
+    local int_part frac scaled
+    int_part=$((bytes / divisor))
+    frac=$(((bytes % divisor) * 100 / divisor)) # 2-decimal residual; good enough for N<=2
+    if ((precision == 0)); then
+        printf '%d%s' "$int_part" "$suffix"
+    elif ((precision == 1)); then
+        # Round to 1 decimal from 2-decimal frac.
+        local rounded_frac=$(((frac + 5) / 10))
+        if ((rounded_frac >= 10)); then
+            int_part=$((int_part + 1))
+            rounded_frac=0
+        fi
+        printf '%d.%d%s' "$int_part" "$rounded_frac" "$suffix"
+    else
+        # General case: scale int_part by 10^precision, add rounded frac.
+        local scale=$((10 ** precision))
+        scaled=$((int_part * scale + (frac * scale / 100 + scale / 200) / 1))
+        # Re-extract (scaled may have rolled over into int_part).
+        if ((scaled >= int_part * scale + scale)); then
+            int_part=$((int_part + 1))
+            scaled=$((scaled - scale * (int_part - bytes / divisor)))
+        fi
+        printf '%d.%0*d%s' "$int_part" "$precision" "$((scaled % scale))" "$suffix"
+    fi
+}
+
+# Format number to human readable with SI suffixes (base 1000, pure bash)
 # Usage: format_metric 1500  # Returns "1.5K"
 # Usage: format_metric 1500000  # Returns "1.5M"
 format_metric() {
     local value="$1"
     local precision="${2:-1}"
-    local suffix="${3:-}"  # optional suffix (e.g., "/s" for rate)
+    local suffix="${3:-}" # optional suffix (e.g., "/s" for rate)
 
-    if (( value >= 1000000000 )); then
-        awk -v v="$value" -v p="$precision" -v s="$suffix" 'BEGIN { printf "%.*fG%s", p, v / 1000000000, s }'
-    elif (( value >= 1000000 )); then
-        awk -v v="$value" -v p="$precision" -v s="$suffix" 'BEGIN { printf "%.*fM%s", p, v / 1000000, s }'
-    elif (( value >= 1000 )); then
-        awk -v v="$value" -v p="$precision" -v s="$suffix" 'BEGIN { printf "%.*fK%s", p, v / 1000, s }'
+    if ((value >= 1000000000)); then
+        _format_scaled_int "$value" 1000000000 "$precision" "G" "$suffix"
+    elif ((value >= 1000000)); then
+        _format_scaled_int "$value" 1000000 "$precision" "M" "$suffix"
+    elif ((value >= 1000)); then
+        _format_scaled_int "$value" 1000 "$precision" "K" "$suffix"
     else
         printf '%d%s' "$value" "$suffix"
     fi
 }
 
-# Format percentage
+# Internal: render int-scaled value with N decimals + double suffix.
+_format_scaled_int() {
+    local value="$1" divisor="$2" precision="$3" prefix="$4" suffix="$5"
+    local scaled=$(((value * 10 ** precision + divisor / 2) / divisor))
+    local int_part=$((scaled / 10 ** precision))
+    local frac=$((scaled % 10 ** precision))
+    printf '%d.%0*d%s%s' "$int_part" "$precision" "$frac" "$prefix" "$suffix"
+}
+
+# Format percentage (pure bash)
 # Usage: format_percent 45.678 1  # Returns "45.7%"
 format_percent() {
     local value="$1"
     local precision="${2:-0}"
 
-    awk -v v="$value" -v p="$precision" 'BEGIN { printf "%.*f%%", p, v }'
+    local formatted
+    formatted=$(_format_float "$value" "$precision")
+    printf '%s%%' "$formatted"
 }
 
 # Pad number with zeros
@@ -160,9 +317,9 @@ clamp() {
     local min="$2"
     local max="$3"
 
-    if (( value < min )); then
+    if ((value < min)); then
         echo "$min"
-    elif (( value > max )); then
+    elif ((value > max)); then
         echo "$max"
     else
         echo "$value"
@@ -176,7 +333,7 @@ in_range() {
     local min="$2"
     local max="$3"
 
-    (( value >= min && value <= max ))
+    ((value >= min && value <= max))
 }
 
 # Validate numeric value with fallback
@@ -196,54 +353,101 @@ validate_number() {
 # Calculations
 # =============================================================================
 
-# Calculate percentage
+# Calculate percentage (pure bash)
 # Usage: calc_percent 25 100  # Returns "25"
 calc_percent() {
     local value="$1"
     local total="$2"
 
-    if (( total == 0 )); then
+    if ((total == 0)); then
         echo 0
         return
     fi
 
-    awk -v v="$value" -v t="$total" 'BEGIN { printf "%.0f", (v / t) * 100 }'
+    # Round to nearest integer percent: (value * 100 + total/2) / total
+    echo $(((value * 100 + total / 2) / total))
 }
 
-# Calculate percentage with decimal
+# Calculate percentage with decimal (pure bash)
 # Usage: calc_percent_decimal 25 100 2  # Returns "25.00"
 calc_percent_decimal() {
     local value="$1"
     local total="$2"
     local precision="${3:-2}"
 
-    if (( total == 0 )); then
+    if ((total == 0)); then
         printf '%.*f' "$precision" 0
         return
     fi
 
-    awk -v v="$value" -v t="$total" -v p="$precision" 'BEGIN { printf "%.*f", p, (v / t) * 100 }'
+    # Compute scaled = round(value * 10^precision * 100 / total)
+    #   = round(value/total * 100 * 10^precision)
+    # Use big-enough intermediate to avoid premature truncation.
+    local scale=$((10 ** precision))
+    local scaled=$(((value * 100 * scale + total / 2) / total))
+    local int_part=$((scaled / scale))
+    local frac=$((scaled % scale))
+    printf '%d.%0*d' "$int_part" "$precision" "$frac"
 }
 
-# Round number
+# Round number (pure bash)
 # Usage: round 3.7  # Returns "4"
 round() {
     local value="$1"
-    awk -v v="$value" 'BEGIN { printf "%.0f", v }'
+    local sign=""
+    if [[ "$value" == -* ]]; then
+        sign="-"
+        value="${value#-}"
+    fi
+    local int_part="${value%%.*}"
+    local frac_part="${value#*.}"
+    [[ "$frac_part" == "$value" ]] && frac_part=""
+    if [[ -n "$frac_part" && ${frac_part:0:1} -ge 5 ]]; then
+        int_part=$((int_part + 1))
+    fi
+    printf '%s%d' "$sign" "$int_part"
 }
 
-# Floor number
+# Floor number (pure bash)
 # Usage: floor 3.7  # Returns "3"
 floor() {
     local value="$1"
-    awk -v v="$value" 'BEGIN { printf "%.0f", v - (v % 1) }'
+    if [[ "$value" == -* ]]; then
+        # For negatives, floor = int_part - 1 if there's a non-zero fractional part.
+        local abs="${value#-}"
+        local int_part="${abs%%.*}"
+        local frac_part="${abs#*.}"
+        [[ "$frac_part" == "$abs" ]] && frac_part=""
+        # Strip leading zeros; "0", "00", "000" all mean "no fraction".
+        local stripped="${frac_part#"${frac_part%%[!0]*}"}"
+        if [[ -n "$stripped" ]]; then
+            int_part=$((int_part + 1))
+        fi
+        printf -- '-%d' "$int_part"
+    else
+        local int_part="${value%%.*}"
+        printf '%d' "$int_part"
+    fi
 }
 
-# Ceiling number
+# Ceiling number (pure bash)
 # Usage: ceiling 3.2  # Returns "4"
 ceiling() {
     local value="$1"
-    awk -v v="$value" 'BEGIN { printf "%.0f", v + (1 - (v % 1)) % 1 }'
+    if [[ "$value" == -* ]]; then
+        # For negatives, ceiling = int_part (no change).
+        local abs="${value#-}"
+        local int_part="${abs%%.*}"
+        printf -- '-%d' "$int_part"
+    else
+        local int_part="${value%%.*}"
+        local frac_part="${value#*.}"
+        [[ "$frac_part" == "$value" ]] && frac_part=""
+        if [[ -n "$frac_part" ]]; then
+            int_part=$((int_part + 1))
+        fi
+        printf '%d' "$int_part"
+    fi
 }
 
 # =============================================================================
@@ -258,13 +462,13 @@ evaluate_condition() {
     local right="$3"
 
     case "$op" in
-        ">"|"gt")  (( left > right )) ;;
-        ">="|"gte"|"ge") (( left >= right )) ;;
-        "<"|"lt")  (( left < right )) ;;
-        "<="|"lte"|"le") (( left <= right )) ;;
-        "=="|"="|"eq") (( left == right )) ;;
-        "!="|"ne") (( left != right )) ;;
-        *) return 1 ;;
+    ">" | "gt") ((left > right)) ;;
+    ">=" | "gte" | "ge") ((left >= right)) ;;
+    "<" | "lt") ((left < right)) ;;
+    "<=" | "lte" | "le") ((left <= right)) ;;
+    "==" | "=" | "eq") ((left == right)) ;;
+    "!=" | "ne") ((left != right)) ;;
+    *) return 1 ;;
     esac
 }
 
@@ -277,11 +481,11 @@ evaluate_condition() {
 format_uptime_seconds() {
     local seconds="$1"
     local days=$((seconds / 86400))
-    local hours=$(( (seconds % 86400) / 3600 ))
-    local minutes=$(( (seconds % 3600) / 60 ))
-    if (( days > 0 )); then
+    local hours=$(((seconds % 86400) / 3600))
+    local minutes=$(((seconds % 3600) / 60))
+    if ((days > 0)); then
         printf '%dd %dh' "$days" "$hours"
-    elif (( hours > 0 )); then
+    elif ((hours > 0)); then
         printf '%dh %dm' "$hours" "$minutes"
     else
         printf '%dm' "$minutes"
@@ -292,7 +496,7 @@ format_uptime_seconds() {
 # Speed Formatting
 # =============================================================================
 
-# Format speed (KB per second) to human readable
+# Format speed (KB per second) to human readable (pure bash)
 # Usage: format_speed 1536     # Returns "1.5M" (input is KB/s)
 # Usage: format_speed 512      # Returns "512K"
 # Usage: format_speed 512 1 "/s"  # Returns "512.0K/s"
@@ -301,11 +505,19 @@ format_speed() {
     local precision="${2:-0}"
     local suffix="${3:-}"
 
-    if (( kb_per_sec >= 1024 )); then
-        awk -v v="$kb_per_sec" -v p="$precision" -v s="$suffix" 'BEGIN { printf "%.*fM%s", p, v / 1024, s }'
+    if ((kb_per_sec >= 1024)); then
+        # M = KB/1024 with N decimals.
+        local scaled=$(((kb_per_sec * 10 ** precision + 512) / 1024))
+        local int_part=$((scaled / 10 ** precision))
+        local frac=$((scaled % 10 ** precision))
+        if ((precision == 0)); then
+            printf '%dM%s' "$int_part" "$suffix"
+        else
+            printf '%d.%0*dM%s' "$int_part" "$precision" "$frac" "$suffix"
+        fi
     else
-        if (( precision > 0 )); then
-            awk -v v="$kb_per_sec" -v p="$precision" -v s="$suffix" 'BEGIN { printf "%.*fK%s", p, v, s }'
+        if ((precision > 0)); then
+            printf '%d.%0*dK%s' "$kb_per_sec" "$precision" 0 "$suffix"
         else
             printf '%dK%s' "$kb_per_sec" "$suffix"
         fi

--- a/tests/aiquotas.bats
+++ b/tests/aiquotas.bats
@@ -324,7 +324,7 @@ setup() {
             local lineno="${rest%%:*}"
             awk -v target="$lineno" '
                 BEGIN { in_seam = 0 }
-                /_aiquotas_http_get(_meta)?\(\)/ { in_seam = 1; next }
+                /_aiquotas_http_get(_meta(_authed)?|_authed)?\(\)/ { in_seam = 1; next }
                 in_seam && /^}/ { in_seam = 0; next }
                 NR == target { exit (in_seam ? 0 : 1) }
             ' "$file"
@@ -1436,7 +1436,7 @@ _setup_aiq_shim_zai() {
             local lineno="${rest%%:*}"
             awk -v target="$lineno" '
                 BEGIN { in_seam = 0 }
-                /_aiquotas_http_get(_meta)?\(\)/ { in_seam = 1; next }
+                /_aiquotas_http_get(_meta(_authed)?|_authed)?\(\)/ { in_seam = 1; next }
                 in_seam && /^}/ { in_seam = 0; next }
                 NR == target { exit (in_seam ? 0 : 1) }
             ' "$file"
@@ -2806,6 +2806,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":80,\"reset_at\":1784781808}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         _aiquotas_collect_openai_codex "$AUTH_FILE" | jq -e "
             (.provider_outcomes[0].status == \"ok\") and
@@ -2927,6 +2928,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":80,\"reset_at\":1784781808},\"secondary_window\":{\"used_percent\":5,\"reset_at\":1784900000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         _aiquotas_collect_openai_codex "$AUTH_FILE" | jq -e "
             (.records[0].value == 80) and
@@ -2958,6 +2960,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":80,\"reset_at\":1784781808}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         _aiquotas_collect_openai_codex "$AUTH_FILE" | jq -e "
             (.records[0].dimensions.interval_remaining_percent == 20) and
@@ -2991,6 +2994,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":80,\"reset_at\":1784781808},\"secondary_window\":{\"used_percent\":5,\"reset_at\":1784900000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         DOC=$(_aiquotas_collect_openai "$AUTH_FILE")
         plugin_data_set "providers_count" "1"
@@ -3024,6 +3028,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limits\":{\"primary_window\":{\"used_percent\":100,\"reset_at\":1784781808},\"secondary_window\":{\"used_percent\":20,\"reset_at\":1784900000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         _aiquotas_collect_openai_codex "$AUTH_FILE" | jq -e "
             (.records[0].value == 100) and
@@ -3057,6 +3062,7 @@ JSON
             # 5h has 0% remaining (exhausted); weekly has 90% remaining.
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"five_hour\":{\"percent_left\":0,\"reset_time_ms\":1752600000000},\"weekly\":{\"percent_left\":90,\"reset_time_ms\":1753200000000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         _aiquotas_collect_openai_codex "$AUTH_FILE" | jq -e "
             (.records[0].value == 100) and
@@ -3093,6 +3099,7 @@ JSON
         _aiquotas_http_get_skim() {
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":100,\"reset_at\":1784781808},\"secondary_window\":{\"used_percent\":10,\"reset_at\":1784900000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         DOC=$(_aiquotas_collect_openai "$AUTH_FILE")
         plugin_data_set "providers_count" "1"
@@ -3132,6 +3139,7 @@ JSON
             # (above warn_th=80). Health must escalate because of the secondary window.
             printf "%s" "{\"plan_type\":\"plus\",\"rate_limit\":{\"primary_window\":{\"used_percent\":5,\"reset_at\":1784781808},\"secondary_window\":{\"used_percent\":85,\"reset_at\":1784900000}}}"
         }
+        _aiquotas_http_get_meta_authed() { _aiquotas_http_get_skim "$@"; }
         _aiquotas_last_status() { printf "200"; }
         DOC=$(_aiquotas_collect_openai "$AUTH_FILE")
         plugin_data_set "providers_count" "1"

--- a/tests/aiquotas.bats
+++ b/tests/aiquotas.bats
@@ -12,6 +12,19 @@ load 'helpers/test_helper'
 setup() {
     setup_test_root
     source "${POWERKIT_ROOT}/src/plugins/aiquotas.sh"
+    # Tests isolate from the parent tmux server: get_tmux_option would
+    # otherwise read @powerkit_plugin_aiquotas_* values left over from the
+    # developer's live tmux session (e.g. openai_source=codex) and steer
+    # collection onto a different branch than the fixtures cover. This is
+    # why several pre-existing tests (48, 51, 54, 66, 106, 117) failed
+    # with empty records in environments where the host tmux had stale
+    # aiquotas options set.
+    unset TMUX
+    # Likewise, set-environment values (e.g. MIMO_API_KEY) inherited from
+    # the host tmux leak into MiMo tests and push collection onto the
+    # HTTP-call branch instead of the unsupported branch the fixtures cover.
+    unset MIMO_SESSION_COOKIES MIMO_API_KEY XIAOMI_MIMO_API_KEY
+    unset OPENAI_ADMIN_KEY OPENAI_API_KEY ANTHROPIC_ADMIN_KEY
 }
 # Note: After the Todo 3 lazy split, _aiquotas_collect_<provider> functions
 # live in src/plugins/aiquotas/*.sh (provider adapters) and are only defined

--- a/tests/benchmark_render.sh
+++ b/tests/benchmark_render.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# =============================================================================
+# PowerKit: Render Cycle Benchmark
+# Description: Measures wall-clock time of N consecutive powerkit-render
+#              invocations to validate Sprint 1/2 performance gains.
+#
+# Usage:
+#   tests/benchmark_render.sh                 # default 100 cycles, side=right
+#   tests/benchmark_render.sh --cycles 500   # 500 cycles
+#   tests/benchmark_render.sh --side left    # render status-left
+#   tests/benchmark_render.sh --quiet        # only summary line
+#
+# Output (default):
+#   - mean / median / p95 / min / max in ms
+#   - cycles-per-second
+#   - optional comparison vs baseline (tests/fixtures/baseline.txt)
+#
+# Environment:
+#   POWERKIT_ROOT must point to the plugin checkout (auto-detected).
+#   BASH must be 5.1+ (validated up front).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Require Bash 5.3+
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
+    printf 'benchmark_render: Bash 5.3+ required, found %s\n' "$BASH_VERSION" >&2
+    exit 1
+fi
+
+# Defaults
+cycles=100
+side="right"
+quiet=0
+baseline=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --cycles)
+        cycles="$2"
+        shift 2
+        ;;
+    --side)
+        side="$2"
+        shift 2
+        ;;
+    --quiet)
+        quiet=1
+        shift
+        ;;
+    --baseline)
+        baseline="$2"
+        shift 2
+        ;;
+    -h | --help)
+        cat <<'EOF'
+Usage: tests/benchmark_render.sh [--cycles N] [--side left|right] [--quiet] [--baseline FILE]
+
+Measures powerkit-render wall-clock time over N cycles.
+
+Options:
+  --cycles N        Number of render invocations (default 100)
+  --side S          Render side: right | left (default right)
+  --quiet           Print only the summary line (mean, median, p95)
+  --baseline FILE   Compare against a baseline mean (ms) and report delta
+EOF
+        exit 0
+        ;;
+    *)
+        printf 'unknown arg: %s\n' "$1" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [[ ! -x "$POWERKIT_ROOT/bin/powerkit-render" ]]; then
+    printf 'benchmark_render: powerkit-render not found at %s/bin/powerkit-render\n' "$POWERKIT_ROOT" >&2
+    exit 1
+fi
+
+if ((quiet == 0)); then
+    printf 'PowerKit Render Benchmark\n'
+    printf '==========================\n'
+    printf 'POWERKIT_ROOT: %s\n' "$POWERKIT_ROOT"
+    printf 'Bash:          %s\n' "$BASH_VERSION"
+    printf 'Cycles:        %d\n' "$cycles"
+    printf 'Side:          %s\n' "$side"
+    printf '\n'
+fi
+
+# Measure cycles via EPOCHREALTIME (microsecond precision; bash 5.0+).
+declare -a timings_ms=()
+
+# Warmup: 3 invocations to amortize first-run cost (cache prime).
+for _ in 1 2 3; do
+    "$POWERKIT_ROOT/bin/powerkit-render" "$side" >/dev/null 2>&1 || true
+done
+
+start_epoch=$EPOCHSECONDS
+for ((i = 0; i < cycles; i++)); do
+    t0=$EPOCHREALTIME
+    "$POWERKIT_ROOT/bin/powerkit-render" "$side" >/dev/null 2>&1 || true
+    t1=$EPOCHREALTIME
+    # EPOCHREALTIME is "seconds.microseconds"; convert to integer ms.
+    diff_s=$((${t1%%.*} - ${t0%%.*}))
+    diff_us="${t1#*.}"
+    diff_us="${diff_us:0:6}"
+    diff_us="000000$diff_us"
+    diff_us="${diff_us: -6}"
+    diff_us_t0="${t0#*.}"
+    diff_us_t0="${diff_us_t0:0:6}"
+    diff_us_t0="000000$diff_us_t0"
+    diff_us_t0="${diff_us_t0: -6}"
+    elapsed_us=$((diff_s * 1000000 + 10#$diff_us - 10#$diff_us_t0))
+    elapsed_ms=$(((elapsed_us + 500) / 1000))
+    timings_ms+=("$elapsed_ms")
+done
+end_epoch=$EPOCHSECONDS
+
+# Compute statistics in pure bash.
+sum=0
+min_ms=-1 max_ms=0
+declare -a sorted=("${timings_ms[@]}")
+
+# Sum + min/max
+for t in "${timings_ms[@]}"; do
+    sum=$((sum + t))
+    ((t < min_ms || min_ms == -1)) && min_ms="$t"
+    ((t > max_ms)) && max_ms="$t"
+done
+
+# Sort (simple bubble; sufficient for N<=10000).
+for ((i = 0; i < cycles; i++)); do
+    for ((j = i + 1; j < cycles; j++)); do
+        if ((sorted[j] < sorted[i])); then
+            tmp="${sorted[i]}"
+            sorted[i]="${sorted[j]}"
+            sorted[j]="$tmp"
+        fi
+    done
+done
+
+mean_ms=$(((sum + cycles / 2) / cycles))
+median_ms="${sorted[$((cycles / 2))]}"
+p95_idx=$(((cycles * 95 + 99) / 100))
+((p95_idx >= cycles)) && p95_idx=$((cycles - 1))
+p95_ms="${sorted[$p95_idx]}"
+total_s=$((end_epoch - start_epoch))
+if ((total_s == 0)); then total_s=1; fi
+cps=$((cycles / total_s))
+
+# Summary
+if ((quiet == 0)); then
+    printf 'Results (%d cycles, side=%s):\n' "$cycles" "$side"
+    printf '  min:    %d ms\n' "$min_ms"
+    printf '  p50:    %d ms\n' "$median_ms"
+    printf '  mean:   %d ms\n' "$mean_ms"
+    printf '  p95:    %d ms\n' "$p95_ms"
+    printf '  max:    %d ms\n' "$max_ms"
+    printf '  throughput: ~%d renders/sec\n' "$cps"
+    printf '\n'
+fi
+
+summary_line="mean=${mean_ms}ms median=${median_ms}ms p95=${p95_ms}ms cycles=${cycles} side=${side} bash=${BASH_VERSION}"
+
+# Baseline comparison (optional).
+if [[ -n "$baseline" && -f "$baseline" ]]; then
+    baseline_mean=$(grep -oE 'mean=[0-9]+' "$baseline" | head -1 | cut -d= -f2)
+    if [[ -n "$baseline_mean" && "$baseline_mean" -gt 0 ]]; then
+        delta_pct=$(((mean_ms * 100 + baseline_mean / 2) / baseline_mean - 100))
+        printf '%s baseline_mean=%dms delta=+%d%%\n' "$summary_line" "$baseline_mean" "$delta_pct"
+    else
+        printf '%s baseline=%s (unparseable)\n' "$summary_line" "$baseline"
+    fi
+else
+    printf '%s\n' "$summary_line"
+fi

--- a/tests/benchmark_render.sh
+++ b/tests/benchmark_render.sh
@@ -25,9 +25,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
-# Require Bash 5.3+
-if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
-    printf 'benchmark_render: Bash 5.3+ required, found %s\n' "$BASH_VERSION" >&2
+# Require Bash 5.2+
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 2))); then
+    printf 'benchmark_render: Bash 5.2+ required, found %s\n' "$BASH_VERSION" >&2
     exit 1
 fi
 

--- a/tests/fixtures/baseline.txt
+++ b/tests/fixtures/baseline.txt
@@ -1,0 +1,1 @@
+mean=84ms median=83ms p95=93ms cycles=100 side=right bash=5.3.15(1)-release

--- a/tests/lib_api.bats
+++ b/tests/lib_api.bats
@@ -122,6 +122,10 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+# Also read stdin (curl --config - pipes config through stdin)
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -130,7 +134,7 @@ done')
         make_api_call "http://test" "github" "ghp_token" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: Authorization: token ghp_token"
+    assert_output --partial "cfg: header = \"Authorization: token ghp_token\""
 }
 
 @test "make_api_call with bearer auth type" {
@@ -142,6 +146,10 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+# Also read stdin (curl --config - pipes config through stdin)
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -150,7 +158,7 @@ done')
         make_api_call "http://test" "bearer" "my_token" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: Authorization: Bearer my_token"
+    assert_output --partial "cfg: header = \"Authorization: Bearer my_token\""
 }
 
 @test "make_api_call with basic auth type" {
@@ -162,6 +170,10 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+# Also read stdin (curl --config - pipes config through stdin)
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -170,7 +182,7 @@ done')
         make_api_call "http://test" "basic" "user:pass" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "user: user:pass"
+    assert_output --partial "cfg: user = \"user:pass\""
 }
 
 @test "make_api_call with private-token auth type" {
@@ -182,6 +194,10 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+# Also read stdin (curl --config - pipes config through stdin)
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -190,7 +206,7 @@ done')
         make_api_call "http://test" "private-token" "glpat_token" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: PRIVATE-TOKEN: glpat_token"
+    assert_output --partial "cfg: header = \"PRIVATE-TOKEN: glpat_token\""
 }
 
 # =============================================================================

--- a/tests/lib_network.bats
+++ b/tests/lib_network.bats
@@ -208,6 +208,9 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -216,7 +219,7 @@ done')
         _network_make_api_call "http://test" "bearer" "mytoken" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: Authorization: Bearer mytoken"
+    assert_output --partial "cfg: header = \"Authorization: Bearer mytoken\""
 }
 
 @test "_network_make_api_call with github auth" {
@@ -228,6 +231,9 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -236,7 +242,7 @@ done')
         _network_make_api_call "http://test" "github" "ghp_xxx" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: Authorization: token ghp_xxx"
+    assert_output --partial "cfg: header = \"Authorization: token ghp_xxx\""
 }
 
 @test "_network_make_api_call with private-token auth" {
@@ -248,6 +254,9 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -256,7 +265,7 @@ done')
         _network_make_api_call "http://test" "private-token" "glpat_xxx" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "H: PRIVATE-TOKEN: glpat_xxx"
+    assert_output --partial "cfg: header = \"PRIVATE-TOKEN: glpat_xxx\""
 }
 
 @test "_network_make_api_call with basic auth" {
@@ -268,6 +277,9 @@ while [[ $# -gt 0 ]]; do
         *) echo "url: $1";;
     esac
     shift
+done
+while IFS= read -r line; do
+    printf "cfg: %s\n" "$line"
 done')
 
     run bash -c '
@@ -276,7 +288,7 @@ done')
         _network_make_api_call "http://test" "basic" "user:pass" 5
     ' _ "$POWERKIT_ROOT"
     assert_success
-    assert_output --partial "user: user:pass"
+    assert_output --partial "cfg: user = \"user:pass\""
 }
 
 # =============================================================================

--- a/tests/plugin_audit_followup.bats
+++ b/tests/plugin_audit_followup.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Additional bats tests for the wave-2 follow-up fixes that complement
+# the security and reliability contracts. Covers:
+#   - swap decimal precision (_to_bytes with floats)
+#   - uptime awk fallback parser (BSD day/min/hr forms)
+#   - api_validate_ip strict IPv6 (rejects garbage, accepts real)
+#   - nowplaying app_priority option presence
+#   - bitwarden narrow scope (no export BW_SESSION in success path)
+# =============================================================================
+
+load './helpers/test_helper.bash'
+
+setup() {
+    setup_test_root
+    mock_dir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$mock_dir"
+    export PATH="$mock_dir:$PATH"
+}
+
+# =============================================================================
+# swap: decimal precision in _to_bytes
+# =============================================================================
+
+@test "swap: _to_bytes handles fractional MB values" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/swap.sh"
+        # 1234.5 MB = 1294467072 bytes; previous impl returned 1293942784
+        # (a 512 KB loss).
+        printf "%s\n" "$(_to_bytes 1234.5 M)"
+        printf "%s\n" "$(_to_bytes 0.75 G)"
+        printf "%s\n" "$(_to_bytes 2.0 T)"
+        printf "%s\n" "$(_to_bytes 0 M)"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "1294467072"
+    assert_output --partial "805306368"
+    assert_output --partial "2199023255552"
+    assert_output --partial "0"
+}
+
+@test "swap: _to_bytes rejects garbage input" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/swap.sh"
+        printf "%s\n" "$(_to_bytes "abc" M)"
+        printf "%s\n" "$(_to_bytes "1.2.3" M)"
+        printf "%s\n" "$(_to_bytes "12; rm" M)"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    # Every line is "0"
+    [[ "$(echo "$output" | wc -l | tr -d ' ')" == "3" ]]
+    [[ "$(echo "$output" | sort -u)" == "0" ]]
+}
+
+# =============================================================================
+# uptime: awk fallback parser handles day/min/hr
+# =============================================================================
+
+@test "uptime: awk fallback recognizes days, hours, minutes" {
+    run bash -c '
+        awk -F"( |,|:)+" '"'"'
+            {
+                if ($5 == "min" || $5 == "mins")     print $4 * 60
+                else if ($5 == "hrs")               print $4 * 3600
+                else if ($5 == "day" || $5 == "days") {
+                    base = $4 * 86400
+                    if ($6 ~ /^[0-9]+$/ && $7 ~ /^[0-9]+$/) {
+                        base += ($6 * 3600) + ($7 * 60)
+                    }
+                    print base
+                }
+                else                                print -1
+            }'"'"' <<<"12:34, up 12 days,  2 users"
+    '
+    assert_success
+    assert_output --partial "1036800"
+}
+
+# =============================================================================
+# api_validate_ip: strict IPv6
+# =============================================================================
+
+@test "api_validate_ip: rejects garbage that the loose regex accepted" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        # Old loose regex accepted "abc:def" because every char is in [0-9a-fA-F:]
+        # and it contains ":". The strict check should reject it because
+        # "abc" is more than 4 hex digits.
+        api_validate_ip "abc:def"
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "api_validate_ip: rejects more than one :: compression" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "1::2::3"
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "api_validate_ip: accepts valid IPv4" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "192.0.2.1"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+@test "api_validate_ip: accepts canonical IPv6" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+@test "api_validate_ip: accepts compressed IPv6 with ::" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "2001:db8::1"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+@test "api_validate_ip: accepts loopback IPv6 ::1" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "::1"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+# =============================================================================
+# nowplaying: app_priority option exists
+# =============================================================================
+
+@test "nowplaying: app_priority option is declared" {
+    # Static check: the option must be declared in plugin_declare_options.
+    run bash -c '
+        awk "/^plugin_declare_options\\(\\)/,/^}/" "$1/src/plugins/nowplaying.sh"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "app_priority"
+}
+
+# =============================================================================
+# bitwarden: narrow scope (no export BW_SESSION on unlock success)
+# =============================================================================
+
+@test "bitwarden: _unlock_bitwarden_bw does not export BW_SESSION" {
+    # Static check: the success path should call save_bw_session but
+    # NOT contain `export BW_SESSION`. The session stays in tmux's
+    # global environment only.
+    run bash -c '
+        awk "/^_unlock_bitwarden_bw\\(\\)/,/^}/" "$1/src/helpers/_bitwarden_common.sh"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    refute_output --partial "export BW_SESSION"
+    assert_output --partial "save_bw_session"
+}
+
+@test "bitwarden: load_bw_session may export BW_SESSION (current-shell only)" {
+    # load_bw_session is the consumer-side helper that exports so the
+    # current helper shell can use bw. This export is acceptable.
+    run bash -c '
+        grep -A 4 "^load_bw_session()" "$1/src/helpers/_bitwarden_common.sh"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "export BW_SESSION"
+}

--- a/tests/plugin_security_reliability.bats
+++ b/tests/plugin_security_reliability.bats
@@ -1,0 +1,543 @@
+#!/usr/bin/env bats
+# =============================================================================
+# BATS tests for the security and reliability contracts introduced by
+# the recent fixes:
+#   - credentials never appear in curl argv
+#   - argv-based dispatch for helpers (no shell interpolation)
+#   - all-failed returns nonzero so the lifecycle can keep stale cache
+#   - validate_ip / validate_json guard API plugins
+# =============================================================================
+
+load './helpers/test_helper.bash'
+
+setup() {
+    setup_test_root
+    mock_dir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$mock_dir"
+    export PATH="$mock_dir:$PATH"
+}
+
+# Helper: stub safe_curl/curl with a recording script
+_capture_curl_argv() {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+# Record every argv element to a file so tests can grep for tokens.
+{
+    printf 'ARGVS:'
+    for a in "$@"; do printf '|%s' "$a"; done
+    printf '\n'
+} >>"$CURL_LOG_FILE"
+# Return success with an empty body unless the test overrides behaviour.
+[[ -f "$CURL_BODY_FILE" ]] && cat "$CURL_BODY_FILE" || true
+EOF
+    chmod +x "$mock_dir/curl"
+    export CURL_LOG_FILE="$BATS_TEST_TMPDIR/curl.log"
+    export CURL_BODY_FILE="$BATS_TEST_TMPDIR/curl.body"
+    : >"$CURL_LOG_FILE"
+    : >"$CURL_BODY_FILE"
+}
+
+# Helper: assert argv captured by _capture_curl_argv does NOT contain a token
+assert_argv_does_not_contain() {
+    local token="$1"
+    run grep -F -- "$token" "$CURL_LOG_FILE"
+    assert_failure
+}
+
+# Helper: assert argv captured by _capture_curl_argv DOES contain a token
+assert_argv_contains() {
+    local token="$1"
+    run grep -F -- "$token" "$CURL_LOG_FILE"
+    assert_success
+}
+
+# =============================================================================
+# jira.sh — basic auth via curl --config
+# =============================================================================
+
+@test "jira: email+token are NOT in curl argv" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"issues":[],"isLast":true}
+JSON
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/jira.sh"
+        get_option() {
+            case "$1" in
+                domain) printf "example.atlassian.net" ;;
+                email) printf "user@example.com" ;;
+                token) printf "PK_TOKEN_SECRET_abc123" ;;
+                jql)   printf "assignee = currentUser()" ;;
+                project) printf "" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context jira
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "PK_TOKEN_SECRET_abc123"
+    assert_argv_does_not_contain "user@example.com"
+}
+
+# =============================================================================
+# gitlab.sh — PRIVATE-TOKEN via stdin
+# =============================================================================
+
+@test "gitlab: PRIVATE-TOKEN is NOT in curl argv" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"statistics":{"counts":{"opened":7}}}
+JSON
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/gitlab.sh"
+        get_option() {
+            case "$1" in
+                url)   printf "https://gitlab.example.com" ;;
+                token) printf "glpat-PK_GITLAB_SECRET_xyz" ;;
+                repos) printf "group/project" ;;
+                show_issues) printf "true" ;;
+                show_mrs)    printf "false" ;;
+                separator)   printf " " ;;
+                icon_issue)  printf "I" ;;
+                icon_mr)     printf "M" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context gitlab
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "glpat-PK_GITLAB_SECRET_xyz"
+}
+
+# =============================================================================
+# github.sh — Authorization via stdin
+# =============================================================================
+
+@test "github: token is NOT in curl argv" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"total_count":3}
+JSON
+
+    # github uses safe_curl directly, with token in header via stdin.
+    # Stub the gh CLI and curl. The test verifies that the token does not
+    # appear in any captured argv element.
+    cat >"$mock_dir/gh" <<'GH'
+#!/usr/bin/env bash
+exit 0
+GH
+    chmod +x "$mock_dir/gh"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/github.sh"
+        get_option() {
+            case "$1" in
+                token) printf "ghp_PK_GITHUB_SECRET_qwerty" ;;
+                repos) printf "" ;;
+                filter_user) printf "" ;;
+                show_issues) printf "true" ;;
+                show_prs)    printf "true" ;;
+                warning_threshold_issues) printf "10" ;;
+                warning_threshold_prs)    printf "10" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context github
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "ghp_PK_GITHUB_SECRET_qwerty"
+}
+
+# =============================================================================
+# externalip.sh — validate IP
+# =============================================================================
+
+@test "externalip: rejects non-IP text and returns nonzero" {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "<html>captive portal login</html>"
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/externalip.sh"
+        get_option() { printf "PK_ICON"; }
+        _set_plugin_context externalip
+        plugin_collect
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "externalip: accepts a valid IPv4" {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "203.0.113.42"
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/externalip.sh"
+        get_option() { printf "PK_ICON"; }
+        _set_plugin_context externalip
+        plugin_collect
+        printf "ip=%s" "$(plugin_data_get ip)"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output "ip=203.0.113.42"
+}
+
+# =============================================================================
+# cloudstatus — unknown provider does not report operational
+# =============================================================================
+
+@test "cloudstatus: surfaces unknown provider as '?'" {
+    # Stub curl to return a payload that jq can parse but does not
+    # contain a recognised status indicator (unknown).
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo '{"status":{"indicator":"unknown"}}'
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/cloudstatus.sh"
+        get_option() {
+            case "$1" in
+                providers) printf "cloudflare" ;;
+                separator) printf " " ;;
+                issues_only) printf "false" ;;
+                timeout) printf "5" ;;
+                icon) printf "I" ;;
+                icon_warning) printf "W" ;;
+                icon_error) printf "E" ;;
+                cache_ttl) printf "300" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context cloudstatus
+        plugin_collect || true
+        printf "output=%s" "$(plugin_data_get output)"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "?"
+}
+
+# =============================================================================
+# crypto.sh — all-failed returns nonzero
+# =============================================================================
+
+@test "crypto: all-failed returns nonzero" {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "not json at all"
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/crypto.sh"
+        get_option() {
+            case "$1" in
+                coins) printf "bitcoin,ethereum" ;;
+                currency) printf "usd" ;;
+                show_change) printf "false" ;;
+                format) printf "compact" ;;
+                separator) printf " " ;;
+                icon) printf "C" ;;
+                cache_ttl) printf "60" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context crypto
+        plugin_collect
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+# =============================================================================
+# stocks.sh — all-failed returns nonzero
+# =============================================================================
+
+@test "stocks: all-failed returns nonzero" {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "<html>not the yahoo API</html>"
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/stocks.sh"
+        get_option() {
+            case "$1" in
+                tickers) printf "AAPL,GOOG" ;;
+                show_ticker) printf "true" ;;
+                show_change) printf "true" ;;
+                format) printf "short" ;;
+                separator) printf " " ;;
+                icon) printf "S" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context stocks
+        plugin_collect
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+# =============================================================================
+# bitbucket.sh — all-failed returns nonzero
+# =============================================================================
+
+@test "bitbucket: all-failed returns nonzero" {
+    cat >"$mock_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "rate limit exceeded"
+EOF
+    chmod +x "$mock_dir/curl"
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/bitbucket.sh"
+        get_option() {
+            case "$1" in
+                repos) printf "owner/repo" ;;
+                show_issues) printf "true" ;;
+                show_prs)    printf "true" ;;
+                type)        printf "cloud" ;;
+                email)       printf "u@e.com" ;;
+                token)       printf "t" ;;
+                url)         printf "" ;;
+                workspace)   printf "" ;;
+                separator)   printf " " ;;
+                icon_issue)  printf "I" ;;
+                icon_pr)     printf "P" ;;
+                icon)        printf "B" ;;
+                format)      printf "compact" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context bitbucket
+        plugin_collect
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+# =============================================================================
+# jira — malformed JSON returns nonzero
+# =============================================================================
+
+@test "jira: malformed body returns nonzero" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'EOF'
+not json
+EOF
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/jira.sh"
+        get_option() {
+            case "$1" in
+                domain) printf "example.atlassian.net" ;;
+                email) printf "u@e.com" ;;
+                token) printf "t" ;;
+                jql)   printf "project = X" ;;
+                project) printf "" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context jira
+        plugin_collect
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+# =============================================================================
+# weather — _release_rate_limit decrements counter on failure
+# =============================================================================
+
+@test "weather: _release_rate_limit rolls back the counter" {
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        export XDG_CACHE_HOME="$2/cache"
+        mkdir -p "$XDG_CACHE_HOME"
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/weather.sh"
+        get_option() { printf "5"; }
+        # Reserve a slot
+        _check_rate_limit
+        before=$(cache_get "weather_rate_limit:$(date +%Y%m%d%H)" 3600)
+        # Release it
+        _release_rate_limit
+        after=$(cache_get "weather_rate_limit:$(date +%Y%m%d%H)" 3600)
+        printf "before=%s after=%s" "$before" "$after"
+    ' _ "$POWERKIT_ROOT" "$BATS_TEST_TMPDIR"
+    assert_success
+    # before is "1" (one slot reserved), after is "0" (released)
+    [[ "$output" == "before=1 after=0" ]]
+}
+
+# =============================================================================
+# helpers — argv-based dispatch (smoke)
+# =============================================================================
+
+@test "audiodevices: _pk_set_input exists and validates name" {
+    # Static check: the helper defines _pk_set_input and uses an
+    # allowlist regex that rejects shell metacharacters.
+    run bash -c '
+        grep -A 18 "^_pk_set_input()" "$1/src/helpers/audiodevices_selector.sh"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "valid name"
+    # Allowlist regex is present
+    grep -q 'A-Za-z0-9._:/@+=,-' "$POWERKIT_ROOT/src/helpers/audiodevices_selector.sh"
+}
+
+@test "terraform: _pk_tf_switch exists and validates path" {
+    # Static check: the helper defines _pk_tf_switch and validates
+    # the pane_path against a safe regex.
+    run bash -c '
+        grep -A 6 "^_pk_tf_switch()" "$1/src/helpers/terraform_workspace_selector.sh" | head -12
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "pane_path"
+    # Allowlist regex is present
+    grep -q 'A-Za-z0-9._+' "$POWERKIT_ROOT/src/helpers/terraform_workspace_selector.sh"
+}
+
+# =============================================================================
+# src/utils/api.sh — new helpers
+# =============================================================================
+
+@test "api_validate_ip accepts a valid IPv4" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "203.0.113.42"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+@test "api_validate_ip rejects arbitrary text" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "<html>portal</html>"
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "api_validate_ip rejects IPv4 with out-of-range octet" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        api_validate_ip "999.0.0.1"
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "api_validate_json accepts parseable JSON" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        api_validate_json "{\"a\":1}"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+}
+
+@test "api_validate_json rejects malformed JSON" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        api_validate_json "not json"
+    ' _ "$POWERKIT_ROOT"
+    assert_failure
+}
+
+@test "api_classify_outcome maps HTTP status codes" {
+    run bash -c '
+        source "$1/src/core/bootstrap.sh"
+        for s in 200 401 403 404 429 500 0; do
+            api_classify_outcome "$s"
+        done
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "success"
+    assert_output --partial "unauthorized"
+    assert_output --partial "forbidden"
+    assert_output --partial "not_found"
+    assert_output --partial "rate_limited"
+    assert_output --partial "server_error"
+    assert_output --partial "transport_error"
+}
+
+# =============================================================================
+# binary_manager — trap + atomic install
+# =============================================================================
+
+@test "binary_manager: binary_download trap removes temp on failure (no -I flag)" {
+    # We don't run the full installer (it would contact GitHub). We
+    # only verify that the function's body contains the trap that
+    # guarantees cleanup, and that the structure has a staged install
+    # before the final mv -f.
+    run bash -c '
+        grep -E "trap .* RETURN" "$1/src/core/binary_manager.sh" | head -2
+        grep -E "staged_file" "$1/src/core/binary_manager.sh" | head -3
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "RETURN"
+    assert_output --partial "staged_file"
+}
+
+# =============================================================================
+# bw_session cleanup on failure
+# =============================================================================
+
+@test "bitwarden: _unlock_bitwarden_bw calls clear_bw_session on the auth-failure path" {
+    # Static check: the function must contain a clear_bw_session call
+    # in the else branch where the password is rejected.
+    run bash -c '
+        awk "/_unlock_bitwarden_bw\\(\\)/,/^}/" "$1/src/helpers/_bitwarden_common.sh"
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "clear_bw_session"
+}
+
+@test "bitwarden: _unlock_bitwarden_bw returns 130 on Ctrl-C instead of recursing" {
+    # Static check for the Ctrl-C exit branch
+    run bash -c '
+        grep -A 2 "130" "$1/src/helpers/_bitwarden_common.sh" | head -8
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_output --partial "clear_bw_session"
+}
+
+# =============================================================================
+# TOTP code never appears in toast text
+# =============================================================================
+
+@test "bitwarden: totp_selector does not interpolate TOTP into toast" {
+    run bash -c '
+        # The toast calls should not contain $totp_code.
+        grep -n "toast.*totp_code" "$1/src/helpers/bitwarden_totp_selector.sh" || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    # No matches: the interpolation was removed
+    [ -z "$output" ]
+}

--- a/tests/plugin_security_reliability.bats
+++ b/tests/plugin_security_reliability.bats
@@ -159,6 +159,43 @@ GH
     assert_argv_does_not_contain "ghp_PK_GITHUB_SECRET_qwerty"
 }
 
+@test "github _verify_token: token is NOT in curl argv when gh is absent" {
+    # Force the _verify_token path by NOT providing gh (so gh auth
+    # status short-circuits fails). Falls through to the API path
+    # which used to leak the token via make_api_call.
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"login":"octocat"}
+JSON
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        PATH="/usr/bin:/bin"   # remove the mock gh from PATH
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/github.sh"
+        get_option() {
+            case "$1" in
+                token) printf "ghp_PK_GITHUB_VERIFY_SECRET_zzzz" ;;
+                repos) printf "" ;;
+                filter_user) printf "" ;;
+                show_issues) printf "true" ;;
+                show_prs)    printf "true" ;;
+                warning_threshold_issues) printf "10" ;;
+                warning_threshold_prs)    printf "10" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context github
+        # Stub only curl (not gh). The plugin should call _verify_token
+        # which now uses api_fetch_with_token_header (stdin).
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "ghp_PK_GITHUB_VERIFY_SECRET_zzzz"
+    # And no "Authorization: token" should appear in argv either
+    assert_argv_does_not_contain "Authorization: token"
+}
+
 # =============================================================================
 # externalip.sh — validate IP
 # =============================================================================
@@ -341,6 +378,76 @@ EOF
         plugin_collect
     ' _ "$POWERKIT_ROOT"
     assert_failure
+}
+
+@test "bitbucket cloud: email+token are NOT in curl argv" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"size":3,"values":[]}
+JSON
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/bitbucket.sh"
+        get_option() {
+            case "$1" in
+                repos) printf "owner/repo" ;;
+                show_issues) printf "true" ;;
+                show_prs)    printf "true" ;;
+                type)        printf "cloud" ;;
+                email)       printf "u@PK_BITBUCKET_SECRET.com" ;;
+                token)       printf "PK_BITBUCKET_SECRET" ;;
+                url)         printf "" ;;
+                workspace)   printf "" ;;
+                separator)   printf " " ;;
+                icon_issue)  printf "I" ;;
+                icon_pr)     printf "P" ;;
+                icon)        printf "B" ;;
+                format)      printf "compact" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context bitbucket
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "PK_BITBUCKET_SECRET"
+    assert_argv_does_not_contain "u@PK_BITBUCKET_SECRET.com"
+}
+
+@test "bitbucket datacenter: token is NOT in curl argv" {
+    _capture_curl_argv
+    cat >"$CURL_BODY_FILE" <<'JSON'
+{"size":3,"values":[]}
+JSON
+
+    run bash -c '
+        POWERKIT_ROOT="$1"; export POWERKIT_ROOT
+        source "$1/src/core/bootstrap.sh"
+        source "$1/src/plugins/bitbucket.sh"
+        get_option() {
+            case "$1" in
+                repos) printf "owner/repo" ;;
+                show_issues) printf "true" ;;
+                show_prs)    printf "true" ;;
+                type)        printf "datacenter" ;;
+                token)       printf "PK_BITBUCKET_DC_SECRET" ;;
+                url)         printf "https://bitbucket.example.com" ;;
+                workspace)   printf "" ;;
+                separator)   printf " " ;;
+                icon_issue)  printf "I" ;;
+                icon_pr)     printf "P" ;;
+                icon)        printf "B" ;;
+                format)      printf "compact" ;;
+                *) printf "" ;;
+            esac
+        }
+        _set_plugin_context bitbucket
+        plugin_collect || true
+    ' _ "$POWERKIT_ROOT"
+    assert_success
+    assert_argv_does_not_contain "PK_BITBUCKET_DC_SECRET"
 }
 
 # =============================================================================

--- a/tests/security_curl_argv.bats
+++ b/tests/security_curl_argv.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Security regression: curl argv must never contain credential material.
+# Plan: .beads/issues/tmux-powerkit-7x8
+#
+# Each test sources a powerkit helper that performs an authenticated
+# request, then verifies via the deterministic curl shim that argv
+# contains NO credential substring. Credentials must travel through
+# --config - (stdin) or be absent entirely from non-auth helpers.
+# =============================================================================
+
+load 'helpers/test_helper'
+
+setup() {
+    setup_test_root
+    unset TMUX
+}
+
+# Install a curl shim that records argv and returns a stub body.
+# Usage: _install_curl_argv_recorder <state_dir>
+_install_curl_argv_recorder() {
+    local state_dir="$1"
+    mkdir -p "$state_dir/bin"
+    cat >"$state_dir/bin/curl" <<'SHIM'
+#!/usr/bin/env bash
+# argv recorder: dumps each arg as a separate line, exits 0
+printf '%s\n' "$@" >"$AIQUOTAS_ARGV_LOG"
+printf '{}'
+SHIM
+    chmod +x "$state_dir/bin/curl"
+}
+
+# Assert that argv contained no credential substring.
+# Usage: assert_argv_clean "<logfile>" "<substring>"
+assert_argv_clean() {
+    local logfile="$1"
+    local needle="$2"
+    if grep -F -q -- "$needle" "$logfile" 2>/dev/null; then
+        echo "FAIL: credential substring '$needle' leaked into curl argv:"
+        cat "$logfile"
+        return 1
+    fi
+}
+
+# =============================================================================
+# api.sh: api_fetch_with_auth (uses --config stdin)
+# =============================================================================
+
+@test "security: api_fetch_with_auth does not leak Authorization to argv" {
+    local state_dir="$(mktemp -d -t aqt.argv.XXXXXX)"
+    _install_curl_argv_recorder "$state_dir"
+    export AIQUOTAS_ARGV_LOG="$state_dir/argv.log"
+
+    run env PATH="$state_dir/bin:$PATH" \
+        bash -c '
+            source "$1/src/core/bootstrap.sh"
+            source "$1/src/utils/api.sh"
+            api_fetch_with_auth "https://api.example.com/x" "Bearer SECRET_TOKEN_AAA"
+        ' _ "$POWERKIT_ROOT"
+
+    assert_success
+    assert_argv_clean "$state_dir/argv.log" "SECRET_TOKEN_AAA"
+    rm -rf "$state_dir"
+}
+
+@test "security: api_fetch_with_auth basic auth does not leak credential" {
+    local state_dir="$(mktemp -d -t aqt.argv.XXXXXX)"
+    _install_curl_argv_recorder "$state_dir"
+    export AIQUOTAS_ARGV_LOG="$state_dir/argv.log"
+
+    run env PATH="$state_dir/bin:$PATH" \
+        bash -c '
+            source "$1/src/core/bootstrap.sh"
+            source "$1/src/utils/api.sh"
+            api_fetch_with_auth "https://api.example.com/x" "Basic dXNlcjpwYXNz"
+        ' _ "$POWERKIT_ROOT"
+
+    assert_success
+    assert_argv_clean "$state_dir/argv.log" "dXNlcjpwYXNz"
+    rm -rf "$state_dir"
+}
+
+# =============================================================================
+# network.sh: safe_curl_with_auth (Basic via stdin)
+# =============================================================================
+
+@test "security: safe_curl_with_auth does not leak Basic user:pass to argv" {
+    local state_dir="$(mktemp -d -t aqt.argv.XXXXXX)"
+    _install_curl_argv_recorder "$state_dir"
+    export AIQUOTAS_ARGV_LOG="$state_dir/argv.log"
+
+    run env PATH="$state_dir/bin:$PATH" \
+        bash -c '
+            source "$1/src/core/bootstrap.sh"
+            source "$1/src/utils/network.sh"
+            safe_curl_with_auth "alice:SECRET_PWD_BBB" "https://api.example.com/x"
+        ' _ "$POWERKIT_ROOT"
+
+    assert_success
+    assert_argv_clean "$state_dir/argv.log" "SECRET_PWD_BBB"
+    rm -rf "$state_dir"
+}
+
+# =============================================================================
+# jira_issue_selector.sh: jira_api_call (Basic via stdin)
+# =============================================================================
+
+@test "security: jira-style helper does not leak email or token to argv" {
+    local state_dir="$(mktemp -d -t aqt.argv.XXXXXX)"
+    _install_curl_argv_recorder "$state_dir"
+    export AIQUOTAS_ARGV_LOG="$state_dir/argv.log"
+
+    run env PATH="$state_dir/bin:$PATH" \
+        bash -c '
+            source "$1/src/core/bootstrap.sh"
+            source "$1/src/utils/api.sh"
+            source "$1/src/utils/network.sh"
+            # The jira helper ultimately calls safe_curl_with_auth.
+            # Verify the seam directly with a dummy Jira-style credential.
+            safe_curl_with_auth "SECRET_EMAIL_CCC:SECRET_TOKEN_CCC" \
+                "https://example.atlassian.net/rest/api/3/search"
+        ' _ "$POWERKIT_ROOT"
+
+    assert_success
+    assert_argv_clean "$state_dir/argv.log" "SECRET_EMAIL_CCC"
+    assert_argv_clean "$state_dir/argv.log" "SECRET_TOKEN_CCC"
+    rm -rf "$state_dir"
+}
+
+# =============================================================================
+# Whole-src audit (regex over src/)
+# =============================================================================
+
+@test "security: no -H Authorization in $() subshells in src/" {
+    local matches
+    matches=$(grep -rln -F '$(' "$POWERKIT_ROOT/src" 2>/dev/null \
+        | xargs grep -l '\-H[[:space:]]*.*Authorization' 2>/dev/null || true)
+    [ -z "$matches" ] || { echo "Matches: $matches"; return 1; }
+}
+
+@test "security: no -u with credential value (':' or '@') in src/" {
+    local matches
+    # Permits -u "" (legitimate opt-out) and -u followed by flag.
+    matches=$(grep -rn --include='*.sh' \
+        -E 'curl[^|;]*[[:space:]]-u[[:space:]]+[^[:space:]-][^[:space:]]*[:@]' \
+        "$POWERKIT_ROOT/src" 2>/dev/null || true)
+    [ -z "$matches" ] || { echo "Matches: $matches"; return 1; }
+}
+
+@test "security: no --user <cred> literal in src/" {
+    local matches
+    matches=$(grep -rn --include='*.sh' \
+        -- "--user[[:space:]]\+[^\"'-]" \
+        "$POWERKIT_ROOT/src" 2>/dev/null || true)
+    [ -z "$matches" ] || { echo "Matches: $matches"; return 1; }
+}

--- a/tests/test_bash_syntax.sh
+++ b/tests/test_bash_syntax.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # =============================================================================
 # PowerKit Test: Bash Syntax Validation
-# Description: Validates bash 4+ syntax for all .sh files
+# Description: Validates bash 5.3+ syntax for all .sh files
 # =============================================================================
 
 set -euo pipefail
@@ -21,9 +21,10 @@ NC='\033[0m' # No Color
 echo "=== Bash Syntax Validation ==="
 echo ""
 
-# Check bash version
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-    echo -e "${RED}ERROR: Bash 4+ required, found ${BASH_VERSION}${NC}"
+# Check bash version (5.3+ required for ${arr[@]@K} and modern features)
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
+    echo -e "${RED}ERROR: Bash 5.3+ required, found ${BASH_VERSION}${NC}"
+    echo -e "${RED}Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)${NC}"
     exit 1
 fi
 

--- a/tests/test_bash_syntax.sh
+++ b/tests/test_bash_syntax.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # =============================================================================
 # PowerKit Test: Bash Syntax Validation
-# Description: Validates bash 5.3+ syntax for all .sh files
+# Description: Validates bash 5.2+ syntax for all .sh files
 # =============================================================================
 
 set -euo pipefail
@@ -21,10 +21,10 @@ NC='\033[0m' # No Color
 echo "=== Bash Syntax Validation ==="
 echo ""
 
-# Check bash version (5.3+ required for ${arr[@]@K} and modern features)
-if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3))); then
-    echo -e "${RED}ERROR: Bash 5.3+ required, found ${BASH_VERSION}${NC}"
-    echo -e "${RED}Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)${NC}"
+# Check bash version (5.2+ required)
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 2))); then
+    echo -e "${RED}ERROR: Bash 5.2+ required, found ${BASH_VERSION}${NC}"
+    echo -e "${RED}Install: brew install bash (macOS) or use distro bash 5.2+ (Linux)${NC}"
     exit 1
 fi
 

--- a/tests/test_bats.sh
+++ b/tests/test_bats.sh
@@ -98,6 +98,7 @@ BATS_FILES=(
     "$SCRIPT_DIR/plugin_nowplaying.bats"
     "$SCRIPT_DIR/plugin_volume.bats"
     "$SCRIPT_DIR/plugin_security_reliability.bats"
+    "$SCRIPT_DIR/plugin_audit_followup.bats"
     "$SCRIPT_DIR/entities_windows.bats"
     "$SCRIPT_DIR/entities_session.bats"
     "$SCRIPT_DIR/plugins_dev2.bats"

--- a/tests/test_bats.sh
+++ b/tests/test_bats.sh
@@ -97,6 +97,7 @@ BATS_FILES=(
     "$SCRIPT_DIR/plugin_weather.bats"
     "$SCRIPT_DIR/plugin_nowplaying.bats"
     "$SCRIPT_DIR/plugin_volume.bats"
+    "$SCRIPT_DIR/plugin_security_reliability.bats"
     "$SCRIPT_DIR/entities_windows.bats"
     "$SCRIPT_DIR/entities_session.bats"
     "$SCRIPT_DIR/plugins_dev2.bats"

--- a/tmux-powerkit.tmux
+++ b/tmux-powerkit.tmux
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-if (( BASH_VERSINFO[0] < 5 )); then
-    printf 'PowerKit requires Bash 5+, you have %s\n' "$BASH_VERSION" >&2
+# PowerKit requires Bash 5.3+. macOS Apple ships bash 3.2; install via Homebrew:
+#   brew install bash
+# Linux: Homebrew bash, Arch, recent rolling distros ship bash 5.3+.
+if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3) )); then
+    printf 'PowerKit requires Bash 5.3+, you have %s\n' "$BASH_VERSION" >&2
+    printf 'Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)\n' >&2
     exit 1
 fi
 # =============================================================================

--- a/tmux-powerkit.tmux
+++ b/tmux-powerkit.tmux
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# PowerKit requires Bash 5.3+. macOS Apple ships bash 3.2; install via Homebrew:
+# PowerKit requires Bash 5.2+. macOS Apple ships bash 3.2; install via Homebrew:
 #   brew install bash
-# Linux: Homebrew bash, Arch, recent rolling distros ship bash 5.3+.
-if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 3) )); then
-    printf 'PowerKit requires Bash 5.3+, you have %s\n' "$BASH_VERSION" >&2
-    printf 'Install: brew install bash (macOS) or use distro bash 5.3+ (Linux)\n' >&2
+# Linux: Ubuntu 24.04 LTS, Debian 12, Fedora 40+ all ship bash 5.2+.
+if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 2) )); then
+    printf 'PowerKit requires Bash 5.2+, you have %s\n' "$BASH_VERSION" >&2
+    printf 'Install: brew install bash (macOS) or use distro bash 5.2+ (Linux)\n' >&2
     exit 1
 fi
 # =============================================================================


### PR DESCRIPTION
## Summary
- Lower runtime gate from Bash 5+ (v6.3.3) to Bash 5.2+ so
  Ubuntu 24.04 LTS, Debian 12, Fedora 40+ ship a compatible bash
  natively.
- Performance: O(1) caches for plugin options, datastore, file
  mtime, templates, and separators; printf -v in render hot path;
  nvidia-smi consolidated from 5 to 1 query.
- Security: closed tmux-powerkit-7x8 (curl argv credential leaks)
  with argv-recorder shim regression tests covering api.sh,
  network.sh, and jira_issue_selector.sh.
- Fixed 6 pre-existing aiquotas.bats failures caused by host
  tmux env leaking into test subshells (TMUX + set-environment
  vars now unset in setup()).
- New Kimi Code (Moonshot AI) provider for aiquotas.

## Breaking change
Runtime gate narrows from `bash 5+` (any 5.x) to `bash 5.2+`.
Users on bash 5.0/5.1 must upgrade before installing this release.

## Test plan
- [x] `tests/run_all_tests.sh` on bash 5.3.15 (Homebrew): 1183/1183 PASS
- [x] `tests/run_all_tests.sh` on bash 5.2.0 (compiled): 1183/1183 PASS
- [x] `tests/benchmark_render.sh`: 84ms/cycle mean, no regression
- [x] CI: ubuntu-latest + macos-latest jobs green
