### PR TITLE
ci(semantic-release): install Homebrew Bash 5.2 on macOS runners

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -30,9 +30,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Install Homebrew Bash 5.2+
+        run: |
+          # macOS Apple /bin/bash is 3.2.57; PowerKit requires 5.2+.
+          # Install via brew and prepend to PATH so subsequent steps use it.
+          if ! [[ "/opt/homebrew/bin/bash" == */bash5* ]] && ! /opt/homebrew/bin/bash -c '(( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 2) ))'; then
+            brew install bash
+          fi
+          /opt/homebrew/bin/bash --version | head -1
+          echo "/opt/homebrew/bin" >>"$GITHUB_PATH"
+
       - name: Validate Build Environment
         run: |
           echo "=== Build Environment ==="
+          echo "Shell: $BASH_VERSION (${BASH:-/bin/bash})"
           echo "OS: $(sw_vers -productName) $(sw_vers -productVersion)"
           echo "Architecture: $(uname -m)"
           echo "Xcode: $(xcodebuild -version | head -n 1)"


### PR DESCRIPTION
The semantic-release build job runs sh scripts/build.sh which trips the 5.2+ runtime gate. macos-latest / macos-15 runners ship Apple bash 3.2.57 in /bin/bash, so the gate fails before clang ever runs. Homebrew bash is 5.3 already on these runners; install it if missing and prepend /opt/homebrew/bin to $GITHUB_PATH so the subsequent steps use it.

This mirrors the Linux-side build step that compiles bash 5.3 from upstream for the ci.yml test job, but skips the compile because brew is faster and the same Homebrew formula applies on all macos-15 / macos-15-intel runners.

Follow-up to PR #247 (which was squash-merged into main as a single perf! commit, dropping this CI fix). Cherry-picked onto a fresh branch from origin/main so semantic-release can pick it up on its next tagged release.

## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Changes

<!-- List of changes with their types (feat/fix/chore/refactor/etc.) -->

- **`<type>(<scope>): <subject>`** - short description
  - Detail 1
  - Detail 2

## Test Plan

<!-- How was this validated? -->

- [ ] `bash tests/run_all_tests.sh` — passes
- [ ] `tests/test_shellcheck.sh` — 0 warnings
- [ ] `pre-commit validate-config` — passes
- [ ] CI matrix (ubuntu + macOS) — passes
- [ ] Manual smoke test of affected plugins

## Verification log

<!-- Paste command output here for reviewers -->

```text
$ bash tests/run_all_tests.sh
... (paste relevant output)

$ shellcheck -S warning bin/ scripts/ tests/
... (paste relevant output)
```

## Out of scope / known follow-up

<!-- Anything discovered but intentionally not fixed in this PR -->

## Checklist

- [ ] Branch is up-to-date with `main`
- [ ] Commit messages follow Conventional Commits
- [ ] No `Co-Authored-By` lines
- [ ] No emoji in commit messages or PR title
- [ ] All tests pass locally
- [ ] No new shellcheck warnings introduced
- [ ] Plugin contract still respected (data only, no UI logic)
- [ ] Cross-platform impact considered (Linux + macOS)