### PR TITLE
fix(semantic-release): use Homebrew Bash for macOS builds

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -33,17 +33,16 @@ jobs:
       - name: Install Homebrew Bash 5.2+
         run: |
           # macOS Apple /bin/bash is 3.2.57; PowerKit requires 5.2+.
-          # Install via brew and prepend to PATH so subsequent steps use it.
-          if ! [[ "/opt/homebrew/bin/bash" == */bash5* ]] && ! /opt/homebrew/bin/bash -c '(( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 2) ))'; then
-            brew install bash
-          fi
-          /opt/homebrew/bin/bash --version | head -1
-          echo "/opt/homebrew/bin" >>"$GITHUB_PATH"
+          brew list --versions bash >/dev/null || brew install bash
+          homebrew_bash="$(brew --prefix bash)/bin/bash"
+          "$homebrew_bash" -c '(( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 2) ))'
+          "$homebrew_bash" --version | head -1
+          echo "HOMEBREW_BASH=$homebrew_bash" >>"$GITHUB_ENV"
 
       - name: Validate Build Environment
         run: |
           echo "=== Build Environment ==="
-          echo "Shell: $BASH_VERSION (${BASH:-/bin/bash})"
+          echo "Build shell: $($HOMEBREW_BASH --version | head -1)"
           echo "OS: $(sw_vers -productName) $(sw_vers -productVersion)"
           echo "Architecture: $(uname -m)"
           echo "Xcode: $(xcodebuild -version | head -n 1)"
@@ -53,7 +52,7 @@ jobs:
         env:
           BUILD_SUFFIX: ${{ matrix.suffix }}
         run: |
-          NEXT_RELEASE_VERSION=build sh scripts/build.sh $BUILD_SUFFIX
+          NEXT_RELEASE_VERSION=build "$HOMEBREW_BASH" scripts/build.sh "$BUILD_SUFFIX"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/tests/ci_workflows.bats
+++ b/tests/ci_workflows.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+setup() {
+    POWERKIT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    WORKFLOW="$POWERKIT_ROOT/.github/workflows/semantic-release.yaml"
+}
+
+@test "semantic release exports the Homebrew Bash executable" {
+    run grep -F 'homebrew_bash="$(brew --prefix bash)/bin/bash"' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+
+    run grep -F 'echo "HOMEBREW_BASH=$homebrew_bash" >>"$GITHUB_ENV"' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+}
+
+@test "semantic release builds with Homebrew Bash instead of sh" {
+    run grep -F 'NEXT_RELEASE_VERSION=build "$HOMEBREW_BASH" scripts/build.sh "$BUILD_SUFFIX"' "$WORKFLOW"
+    [ "$status" -eq 0 ]
+
+    run grep -E '(^|[[:space:]])sh[[:space:]]+scripts/build\.sh' "$WORKFLOW"
+    [ "$status" -ne 0 ]
+}

--- a/tests/test_bats.sh
+++ b/tests/test_bats.sh
@@ -29,6 +29,7 @@ BATS_FILES=(
     # === Helpers ===
     "$SCRIPT_DIR/tmux_smoke.bats"
     "$SCRIPT_DIR/security.bats"
+    "$SCRIPT_DIR/ci_workflows.bats"
     "$SCRIPT_DIR/aiquotas.bats"
 
     # === Core ===


### PR DESCRIPTION
## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Changes

<!-- List of changes with their types (feat/fix/chore/refactor/etc.) -->

- **`<type>(<scope>): <subject>`** - short description
  - Detail 1
  - Detail 2

## Test Plan

<!-- How was this validated? -->

- [ ] `bash tests/run_all_tests.sh` — passes
- [ ] `tests/test_shellcheck.sh` — 0 warnings
- [ ] `pre-commit validate-config` — passes
- [ ] CI matrix (ubuntu + macOS) — passes
- [ ] Manual smoke test of affected plugins

## Verification log

<!-- Paste command output here for reviewers -->

```text
$ bash tests/run_all_tests.sh
... (paste relevant output)

$ shellcheck -S warning bin/ scripts/ tests/
... (paste relevant output)
```

## Out of scope / known follow-up

<!-- Anything discovered but intentionally not fixed in this PR -->

## Checklist

- [ ] Branch is up-to-date with `main`
- [ ] Commit messages follow Conventional Commits
- [ ] No `Co-Authored-By` lines
- [ ] No emoji in commit messages or PR title
- [ ] All tests pass locally
- [ ] No new shellcheck warnings introduced
- [ ] Plugin contract still respected (data only, no UI logic)
- [ ] Cross-platform impact considered (Linux + macOS)