### PR TITLE
fix(renderer): derive window boundaries from tmux flags

### DIFF
--- a/src/renderer/compositor.sh
+++ b/src/renderer/compositor.sh
@@ -275,10 +275,9 @@ _get_windows_format_left_centered() {
     # === EXIT EDGE SEPARATOR ===
     # From last window's bg to statusbar-bg
     # ▶: fg = origin (last window), bg = destination (gap)
-    # Last window index = base-index + session_windows - 1
     if [[ -n "$sep_char" ]]; then
         local last_bg
-        last_bg="#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},${active_bg},${inactive_bg}}"
+        last_bg="#{W:#{?window_end_flag,${inactive_bg},},#{?window_end_flag,${active_bg},}}"
         fmt+="#[fg=${last_bg},bg=${status_bg}]${sep_char}"
     fi
 
@@ -359,10 +358,10 @@ _get_windows_format_right_centered() {
         # Determine which background to use based on show_index settings
         if [[ "$show_index_active" == "false" && "$show_index_inactive" == "false" ]]; then
             # Never show index, use content color
-            first_bg="#{?#{==:#{active_window_index},#{base-index}},$(resolve_color 'window-active-base'),${first_content_bg}}"
+            first_bg="#{W:#{?window_start_flag,${first_content_bg},},#{?window_start_flag,$(resolve_color 'window-active-base'),}}"
         elif [[ "$show_index_active" == "true" || "$show_index_inactive" == "true" ]]; then
             # Show index for at least one state, use index color
-            first_index_bg="#{?#{==:#{active_window_index},#{base-index}},${active_index_bg},${inactive_index_bg}}"
+            first_index_bg="#{W:#{?window_start_flag,${inactive_index_bg},},#{?window_start_flag,${active_index_bg},}}"
             first_bg="$first_index_bg"
         else
             first_bg="$first_index_bg"
@@ -403,8 +402,7 @@ _get_windows_format_right_centered() {
         if [[ -n "$exit_sep_char" ]]; then
             active_bg=$(resolve_color "window-active-base")
             inactive_bg=$(resolve_color "window-inactive-base")
-            # Last window index = base-index + session_windows - 1
-            last_bg="#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},${active_bg},${inactive_bg}}"
+            last_bg="#{W:#{?window_end_flag,${inactive_bg},},#{?window_end_flag,${active_bg},}}"
             fmt+="#[fg=${last_bg},bg=${status_bg}]${exit_sep_char}"
         fi
     fi
@@ -456,10 +454,10 @@ _get_windows_format_centered() {
         # Determine which background to use based on show_index settings
         if [[ "$show_index_active" == "false" && "$show_index_inactive" == "false" ]]; then
             # Never show index, use content color
-            first_bg="#{?#{==:#{active_window_index},#{base-index}},$(resolve_color 'window-active-base'),${first_content_bg}}"
+            first_bg="#{W:#{?window_start_flag,${first_content_bg},},#{?window_start_flag,$(resolve_color 'window-active-base'),}}"
         elif [[ "$show_index_active" == "true" || "$show_index_inactive" == "true" ]]; then
             # Show index for at least one state, use index color
-            first_index_bg="#{?#{==:#{active_window_index},#{base-index}},${active_index_bg},${inactive_index_bg}}"
+            first_index_bg="#{W:#{?window_start_flag,${inactive_index_bg},},#{?window_start_flag,${active_index_bg},}}"
             first_bg="$first_index_bg"
         else
             first_bg="$first_index_bg"
@@ -499,7 +497,7 @@ _get_windows_format_centered() {
     exit_sep_char=$(get_edge_right_separator)
     if [[ -n "$exit_sep_char" ]]; then
         local last_bg
-        last_bg="#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},${active_bg},${inactive_bg}}"
+        last_bg="#{W:#{?window_end_flag,${inactive_bg},},#{?window_end_flag,${active_bg},}}"
         fmt+="#[fg=${last_bg},bg=${status_bg}]${exit_sep_char}"
     fi
 
@@ -529,9 +527,8 @@ _build_left_edge_separator() {
     inactive_bg=$(resolve_color "window-inactive-base")
 
     # Conditional: if last window is active, use active_bg; else use inactive_bg
-    # Last window index = base-index + session_windows - 1
     local last_bg
-    last_bg="#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},${active_bg},${inactive_bg}}"
+    last_bg="#{W:#{?window_end_flag,${inactive_bg},},#{?window_end_flag,${active_bg},}}"
 
     # Build separator: fg=last_element_bg (origin), bg=status_bg (destination)
     printf '#[fg=%s,bg=%s]%s' "$last_bg" "$status_bg" "$sep_char"
@@ -556,9 +553,8 @@ _build_windows_exit_separator() {
     inactive_bg=$(resolve_color "window-inactive-base")
 
     # Conditional: if last window is active, use active_bg; else use inactive_bg
-    # Last window index = base-index + session_windows - 1
     local last_bg
-    last_bg="#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},${active_bg},${inactive_bg}}"
+    last_bg="#{W:#{?window_end_flag,${inactive_bg},},#{?window_end_flag,${active_bg},}}"
 
     # Powerline convention: fg = origin, bg = destination
     # For window → gap: fg = window, bg = gap

--- a/src/renderer/entities/windows.sh
+++ b/src/renderer/entities/windows.sh
@@ -140,19 +140,15 @@ _windows_build_separator() {
         local spacing_sep_char
         spacing_sep_char=$(_windows_get_spacing_sep_char)
 
-        # Check for first window - use #{base-index} to support both base-index=0 and base-index=1
-        local is_first='#{?#{==:#{window_index},#{base-index}},'
-        local not_first='#{?#{!=:#{window_index},#{base-index}},'
-
         if [[ "$side" == "left" ]]; then
             # Left side ▶: gap → window
             # ▶: fg=gap (left), bg=window (right)
             # When :all suffix is enabled, first window uses edge separator
             if [[ "$_W_ROUND_ALL_EDGES" == "true" ]]; then
                 # First window: edge separator, others: normal separator
-                printf '%s#[fg=%s#,bg=%s]%s,%s#[fg=%s#,bg=%s]%s,}' \
-                    "$is_first" "$spacing_fg" "$index_bg" "$_W_EDGE_SEP_CHAR" \
-                    "$not_first" "$spacing_fg" "$index_bg" "$spacing_sep_char"
+                printf '#{?window_start_flag,#[fg=%s#,bg=%s]%s,#[fg=%s#,bg=%s]%s}' \
+                    "$spacing_fg" "$index_bg" "$_W_EDGE_SEP_CHAR" \
+                    "$spacing_fg" "$index_bg" "$spacing_sep_char"
             else
                 printf '#[fg=%s#,bg=%s]%s' "$spacing_fg" "$index_bg" "$spacing_sep_char"
             fi
@@ -160,22 +156,21 @@ _windows_build_separator() {
             # Center side ▶: gap → window
             # ▶: fg=gap (left), bg=window (right)
             # Skip first window - compositor handles edge separator
-            printf '%s#[fg=%s#,bg=%s]%s,}' "$not_first" "$spacing_fg" "$index_bg" "$spacing_sep_char"
+            printf '#{?window_start_flag,,#[fg=%s#,bg=%s]%s}' "$spacing_fg" "$index_bg" "$spacing_sep_char"
         elif [[ "$side" == "right" ]]; then
             # Right side ◀: gap → window
             # ◀: fg=window (right), bg=gap (left)
             # Skip first window - compositor handles edge separator
-            printf '%s#[fg=%s#,bg=%s]%s,}' "$not_first" "$index_bg" "$spacing_fg" "$spacing_sep_char"
+            printf '#{?window_start_flag,,#[fg=%s#,bg=%s]%s}' "$index_bg" "$spacing_fg" "$spacing_sep_char"
         fi
     else
         # For all sides, first window doesn't need edge separator (handled by compositor)
         # Only add inter-window separators (window 2+)
-        # Use #{base-index} to support both base-index=0 and base-index=1
         if [[ "$side" == "left" || "$side" == "center" ]]; then
-            printf '#{?#{!=:#{window_index},#{base-index}},#[fg=%s#,bg=%s]%s,}' "$previous_bg" "$index_bg" "$_W_SEP_CHAR"
+            printf '#[fg=%s,bg=%s]#{?window_start_flag,,%s}' "$previous_bg" "$index_bg" "$_W_SEP_CHAR"
         else
             # Right side: separator points left (◀)
-            printf '#{?#{!=:#{window_index},#{base-index}},#[fg=%s#,bg=%s]%s,}' "$index_bg" "$previous_bg" "$_W_SEP_CHAR"
+            printf '#[fg=%s,bg=%s]#{?window_start_flag,,%s}' "$index_bg" "$previous_bg" "$_W_SEP_CHAR"
         fi
     fi
 }
@@ -250,22 +245,15 @@ _windows_build_spacing() {
     local spacing_sep_char
     spacing_sep_char=$(_windows_get_spacing_sep_char)
 
-    # Exit separator: window → gap (between windows only)
-    # Skip for LAST window (edge separator handled by compositor)
-    # Last window index = base-index + session_windows - 1
-    local not_last_cond='#{?#{!=:#{window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},'
-
     if [[ "$side" == "left" || "$side" == "center" ]]; then
         # Left side ▶: window → gap
         # ▶: fg=window (left), bg=gap (right)
-        printf '%s#[fg=%s#,bg=%s]%s,}' \
-            "$not_last_cond" \
+        printf '#{?window_end_flag,,#[fg=%s#,bg=%s]%s}' \
             "$content_bg" "$spacing_fg" "$spacing_sep_char"
     else
         # Right side ◀: window → gap
         # ◀: fg=gap (right), bg=window (left)
-        printf '%s#[fg=%s#,bg=%s]%s,}' \
-            "$not_last_cond" \
+        printf '#{?window_end_flag,,#[fg=%s#,bg=%s]%s}' \
             "$spacing_fg" "$content_bg" "$spacing_sep_char"
     fi
 }
@@ -286,7 +274,11 @@ _windows_build_format() {
     # Previous window background for transitions
     local active_content_bg previous_bg
     active_content_bg=$(resolve_color "window-active-base")
-    previous_bg="#{?#{==:#{e|-:#{window_index},1},#{active_window_index}},${active_content_bg},${content_bg}}"
+    
+    # Use nested W formats to check if the window immediately preceding this one is active.
+    # This correctly handles non-contiguous window indices.
+    local prev_is_active='#{m:*=1|#{window_index}=*,#{W:|#{window_index}=0,|#{window_index}=1}}'
+    previous_bg="#{?${prev_is_active},${active_content_bg},${content_bg}}"
 
     # Window content assembled by contract helper (icon + title)
     local window_content
@@ -410,9 +402,8 @@ windows_get_first_bg() {
     active_index_bg=$(resolve_color "window-active-base-lighter")
     inactive_index_bg=$(resolve_color "window-inactive-base-lighter")
 
-    # If first window (base-index) is active, use active color; else use inactive
-    # Use #{base-index} to support both base-index=0 and base-index=1
-    printf '#{?#{==:#{active_window_index},#{base-index}},%s,%s}' "$active_index_bg" "$inactive_index_bg"
+    # Use W format to reliably get the first window's state regardless of non-contiguous indices
+    printf '#{W:#{?window_start_flag,%s,},#{?window_start_flag,%s,}}' "$inactive_index_bg" "$active_index_bg"
 }
 
 # Get the background color of the last window (for outgoing separator)
@@ -422,9 +413,8 @@ windows_get_last_bg() {
     active_content_bg=$(resolve_color "window-active-base")
     inactive_content_bg=$(resolve_color "window-inactive-base")
 
-    # If last window is active, use active color; else use inactive
-    # Last window index = base-index + session_windows - 1
-    printf '#{?#{==:#{active_window_index},#{e|-:#{e|+:#{base-index},#{session_windows}},1}},%s,%s}' "$active_content_bg" "$inactive_content_bg"
+    # Use W format to reliably get the last window's state regardless of non-contiguous indices
+    printf '#{W:#{?window_end_flag,%s,},#{?window_end_flag,%s,}}' "$inactive_content_bg" "$active_content_bg"
 }
 
 # Configure window formats in tmux


### PR DESCRIPTION
Feel free to change anything here. Rewrite it, rename things, or just take the idea and implement it your way. I have no attachment to this particular implementation.

## The problem

First/last window detection compares `#{window_index}` against `#{base-index}`, and works out the last index as `base-index + session_windows - 1`. That only holds while window indices are contiguous.

Delete a window from the middle of the list and the arithmetic points at the wrong window, so separators and edge colours render on the wrong tab until the indices get renumbered.

I hit this running a few sessions with a dozen or so windows each, one window per task, closing them out of order as work finishes. With `base-index 1` that leaves gaps in the sequence constantly, and the status line kept drawing the edge separator on the wrong tab. Worth noting that `renumber-windows on` hides the problem entirely, which is probably why it isn't more visible: I turned it on myself a few weeks after writing this patch, and the symptom went away without the underlying arithmetic being any more correct.

## The change

Use `#{window_start_flag}` and `#{window_end_flag}` instead, and read neighbouring window state through nested `#{W:...}` formats rather than recomputing indices. Both are correct whatever `base-index` is set to, and whatever gaps exist in the sequence.

Touches `src/renderer/entities/windows.sh` and `src/renderer/compositor.sh`. Net -14 lines. No new options, no config changes.

## Tests

`bash tests/run_all_tests.sh`: 1192 tests, 3 failures. All three fail identically on unmodified `main`, so nothing here is new:

```
not ok 639 evaluate_threshold_health_float 85.0 70.0 90.0 0 returns warning
not ok 970 loadavg high load above warning threshold reports warning
not ok 971 loadavg critical load above critical threshold reports error
```

I confirmed that by running the same test files with `POWERKIT_ROOT` pointed at a clean `main` worktree. None of them touch the renderer.

`shellcheck -S warning` on both changed files: clean.

Also smoke tested on 3 sessions and 20 windows with `base-index 1`, including a session with gaps after deleting a window from the middle.

## Two things worth flagging

There's no regression test for the non-contiguous case yet. Happy to add one to `entities_windows.bats` if you want it in this PR.

Unrelated, but you may want to know: some tests in `contract_window.bats` seed `_TMUX_OPTIONS_CACHE`, but the code under test still reads the live tmux server. So they pass or fail depending on the developer's own `.tmux.conf`. On my machine tests 11, 13 and 20 fail on clean `main`, and pass once tmux is pointed at a config-free socket. CI isn't affected, since its tmux has no user config. I can open a separate issue if that's useful.
