### PR TITLE
feat(windows): add per-command window icon overrides

### DIFF
--- a/src/contract/window_contract.sh
+++ b/src/contract/window_contract.sh
@@ -228,8 +228,38 @@ window_get_icon_format() {
         substitutions+="${substitutions:+;}s|^${cmd}$|${icon}|"
     done
 
-    printf '#{?#{m/r:^(%s)$,#{pane_current_command}},#{%s:pane_current_command},%s}' \
+    local format
+    printf -v format '#{?#{m/r:^(%s)$,#{pane_current_command}},#{%s:pane_current_command},%s}' \
         "$command_pattern" "$substitutions" "$default_icon"
+
+    # User-defined per-command icon overrides from ~/.tmux.conf.
+    # Format: "cmd=icon,cmd=icon" (e.g. "fish=,node=").
+    # Applied after the built-in map so user entries take precedence.
+    #
+    # These stay as #{?...} conditionals rather than being folded into the
+    # substitution list above: an override value may itself be a format (e.g.
+    # "#{E:@cc_icon}", used to drive a live per-pane glyph), and a substitution
+    # replacement is emitted literally rather than expanded.
+    local overrides
+    overrides=$(get_tmux_option "@powerkit_window_command_icons" "")
+    if [[ -n "$overrides" ]]; then
+        local pair
+        local -a override_pairs
+        IFS=',' read -ra override_pairs <<< "$overrides"
+        for pair in "${override_pairs[@]}"; do
+            # Skip entries without a '=' separator
+            [[ "$pair" != *"="* ]] && continue
+            cmd="${pair%%=*}"
+            icon="${pair#*=}"
+            # Trim surrounding whitespace from the command name
+            cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+            cmd="${cmd%"${cmd##*[![:space:]]}"}"
+            [[ -z "$cmd" ]] && continue
+            format="#{?#{==:#{pane_current_command},$cmd},$icon,$format}"
+        done
+    fi
+
+    printf '%s' "$format"
 }
 
 # Simpler icon format (just returns default or custom)

--- a/src/core/defaults.sh
+++ b/src/core/defaults.sh
@@ -369,6 +369,14 @@ POWERKIT_DEFAULT_WINDOW_BELL_ICON=$'\U000f009a' # nf-md-bell_alert
 # @powerkit_window_marked_icon - Icon for marked windows (M flag)
 POWERKIT_DEFAULT_WINDOW_MARKED_ICON=$'\U000f0306' # nf-md-bookmark
 
+# @powerkit_window_command_icons - Per-command icon overrides
+# Overrides (or extends) the built-in command->icon map (WINDOW_ICON_MAP).
+# Format: comma-separated "command=icon" pairs. User entries take precedence
+# over the built-in map, so this can remap commands like fish/bash to a
+# different glyph without editing the source.
+#   Example: set -g @powerkit_window_command_icons 'fish=,node='
+# Default: empty (built-in map only)
+
 # @powerkit_pane_synchronized_icon - Icon for synchronized panes
 POWERKIT_DEFAULT_PANE_SYNCHRONIZED_ICON=$'\U00002735'
 

--- a/src/helpers/options_viewer.sh
+++ b/src/helpers/options_viewer.sh
@@ -76,6 +76,7 @@ declare -a THEME_OPTIONS=(
     "@powerkit_zoomed_window_icon||icon|Zoomed pane indicator"
     "@powerkit_pane_synchronized_icon||icon|Synchronized panes indicator"
     "@powerkit_window_default_icon||icon|Default window icon"
+    "@powerkit_window_command_icons||string|Per-command icon overrides (cmd=icon,...)"
     "@powerkit_active_window_title|#W|tmux format|Active window title format"
     "@powerkit_inactive_window_title|#W|tmux format|Inactive window title format"
     "@powerkit_window_index_style|text|text,numeric,box,box_outline,box_multiple,box_multiple_outline,circle,circle_outline|Window index display style"


### PR DESCRIPTION
Feel free to change anything here. Rewrite it, rename the option, or just take the idea and implement it your way. I have no attachment to this particular implementation.

## The use case

When I have multiple things running, such as multiple claude code sessions, I wanted the tabs to tell me at a glance which ones are working, which are waiting on me, and which have stopped. A small script tracks each session's state and writes a glyph into a pane-scoped option as it changes.

The blocker was that the built-in map gives one static icon per command. Every one of those windows runs `claude`, so they all got the same icon and the tab told me nothing. What I needed was for the icon to be a format that gets expanded per window at render time, not a fixed glyph chosen when the format is built.

That turned out to be a small change, and remapping commands to your own glyphs without patching `registry.sh` seems generally useful, so this PR is the general version of it.

## What this adds

`@powerkit_window_command_icons`, a comma-separated list of `command=icon` pairs that overrides or extends the built-in `WINDOW_ICON_MAP` without editing the source:

```tmux
set -g @powerkit_window_command_icons 'fish=,node='
```

Off by default. With the option unset, the emitted format is byte-identical to what `main` produces today.

3 files, +40 -1. No renderer changes.

## Why the overrides aren't folded into the substitution list

The built-in map compiles down to one `#{m/r:...}` match plus a single `#{s|...|}` substitution list. This PR leaves that alone. User overrides are wrapped around it as `#{?...}` conditionals instead.

That's deliberate rather than an oversight. A substitution replacement is emitted literally rather than expanded, so an override whose value is itself a format would print the format text. Keeping overrides as conditionals is what makes this work:

```tmux
set -g @powerkit_window_command_icons 'claude=#{E:@cc_icon}'
```

`@cc_icon` is a pane-scoped option updated by an external script, so the tab shows a live glyph that changes while the command runs. Folded into the substitution list, it would render the literal string `#{E:@cc_icon}`.

The cost is one conditional per override the user actually defines, and none at all when the option is unset.

## Tests

`bash tests/run_all_tests.sh`: 1192 tests, 3 failures. All three fail identically on unmodified `main`, so nothing here is new:

```
not ok 639 evaluate_threshold_health_float 85.0 70.0 90.0 0 returns warning
not ok 970 loadavg high load above warning threshold reports warning
not ok 971 loadavg critical load above critical threshold reports error
```

None are related to window icons.

`window_get_icon_format uses one conditional regardless of icon count` still passes. With the option unset there's exactly one `#{?`, same as today. Overrides only add conditionals when a user opts in.

`shellcheck -S warning` on all three changed files: clean. Smoke tested across 20 panes running claude, fish, nvim and paru.

## Known gaps

Override values go into the format verbatim, so a value containing a comma gets read as a pair separator. I documented that in `defaults.sh` rather than escaping it, to keep the parser simple. Happy to add escaping if you'd prefer.

No test for the override path yet. Can add one.
