### PR TITLE
feat(packages): add multi-backend support with 17 package managers

### DIFF
--- a/src/plugins/packages.sh
+++ b/src/plugins/packages.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # =============================================================================
 # Plugin: packages
-# Description: Display pending package updates
-# Dependencies: package manager (brew/apt/yum/dnf/pacman/yay)
+# Description: Display pending package updates (multi-backend)
+# Dependencies: package manager (brew/zb/apt/yum/dnf/pacman/yay/nix-env/mise/
+#               flatpak/zypper/emerge/apk/pkg/snap/pamac/port)
 # =============================================================================
 
 POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
@@ -15,7 +16,7 @@ POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && p
 plugin_get_metadata() {
     metadata_set "id" "packages"
     metadata_set "name" "Packages"
-    metadata_set "description" "Display pending package updates"
+    metadata_set "description" "Display pending package updates (multi-backend)"
 }
 
 # =============================================================================
@@ -23,7 +24,10 @@ plugin_get_metadata() {
 # =============================================================================
 
 plugin_check_dependencies() {
-    require_any_cmd "brew" "apt" "yum" "dnf" "pacman" "yay" || return 1
+    require_any_cmd \
+        "brew" "zb" "apt" "yum" "dnf" "pacman" "yay" \
+        "nix-env" "mise" "flatpak" "zypper" "emerge" \
+        "apk" "pkg" "snap" "pamac" "port" || return 1
     return 0
 }
 
@@ -33,7 +37,8 @@ plugin_check_dependencies() {
 
 plugin_declare_options() {
     # Backend selection
-    declare_option "backend" "enum" "auto" "Package manager: auto, brew, yay, apt, dnf, yum, pacman"
+    declare_option "backend"  "enum"   "auto" "Single package manager (legacy): auto, brew, zb, yay, apt, dnf, yum, pacman, nix, mise, flatpak, zypper, emerge, apk, pkg, snap, pamac, port"
+    declare_option "backends" "string" ""     "Comma-separated backends to aggregate (e.g. 'brew,zb'). Overrides 'backend' option."
     declare_option "brew_options" "string" "" "Additional options for brew outdated (e.g., '--greedy' for all casks)"
 
     # Display options
@@ -109,30 +114,48 @@ plugin_get_icon() { get_option "icon"; }
 declare -A _PKG_LOG_FILES=(
     [pacman]="/var/log/pacman.log"
     [yay]="/var/log/pacman.log"
+    [pamac]="/var/log/pacman.log"
     [apt]="/var/log/dpkg.log"
     [dnf]="/var/log/dnf.log"
+    [zypper]="/var/log/zypp/history"
+    [apk]="/var/log/apk/world"
+    [snap]="/var/log/syslog"
 )
 
-_invalidate_if_upgraded() {
+# Invalidate the per-backend cache if the package log/dir was modified
+# more recently than the cache was written (i.e., packages were upgraded
+# since the last check).
+_invalidate_backend_cache() {
     local backend="$1"
     local log_file="${_PKG_LOG_FILES[$backend]:-}"
 
-    # brew: use var/homebrew/linked dir mtime (updated on install/upgrade/uninstall)
-    if [[ "$backend" == "brew" ]]; then
+    # brew / zb / port: use a directory mtime instead of a log file
+    case "$backend" in
+    brew)
         local brew_prefix
         brew_prefix="$(command brew --prefix 2>/dev/null)"
-        # Try linked dir first (most reliable), then locks, then Cellar
-        for dir in "$brew_prefix/var/homebrew/linked" "$brew_prefix/var/homebrew/locks" "$brew_prefix/Cellar"; do
-            if [[ -d "$dir" ]]; then
-                log_file="$dir"
-                break
-            fi
+        for dir in "$brew_prefix/var/homebrew/linked" \
+                   "$brew_prefix/var/homebrew/locks" \
+                   "$brew_prefix/Cellar"; do
+            [[ -d "$dir" ]] && { log_file="$dir"; break; }
         done
-    fi
+        ;;
+    zb)
+        for dir in "/opt/zerobrew/var/homebrew/linked" \
+                   "/opt/zerobrew/Cellar" \
+                   "/opt/zerobrew"; do
+            [[ -d "$dir" ]] && { log_file="$dir"; break; }
+        done
+        ;;
+    port)
+        for dir in "/opt/local/var/db/port" "/opt/local"; do
+            [[ -d "$dir" ]] && { log_file="$dir"; break; }
+        done
+        ;;
+    esac
 
     [[ -z "$log_file" || ! -e "$log_file" ]] && return 0
 
-    # Get log/dir modification time
     local log_mtime log_age
     local current_time=$EPOCHSECONDS
     if is_macos; then
@@ -143,65 +166,78 @@ _invalidate_if_upgraded() {
 
     log_age=$((current_time - log_mtime))
 
-    # Check packages cache age (the expensive operation cache)
     local pkg_cache_age
-    pkg_cache_age=$(cache_age "$_PACKAGES_CACHE_KEY")
+    pkg_cache_age=$(cache_age "$(_pkg_cache_key "$backend")")
 
-    # Nothing to invalidate if no cache exists
     [[ "${pkg_cache_age:-0}" -le 0 ]] && return 0
 
-    # If log/dir was modified more recently than packages cache, invalidate it
-    # This means brew install/upgrade/uninstall was run after last check
     if ((log_age < pkg_cache_age)); then
-        cache_clear "$_PACKAGES_CACHE_KEY"
-        cache_clear "$_PACKAGES_SECURITY_CACHE_KEY"
-        # Also clear render cache to force immediate refresh
+        cache_clear "$(_pkg_cache_key "$backend")"
+        cache_clear "$(_pkg_security_cache_key "$backend")"
         cache_clear "plugin_packages_data"
     fi
 }
 
-# =============================================================================
-# Cache Key
-# =============================================================================
-
-_PACKAGES_CACHE_KEY="packages_updates"
-_PACKAGES_SECURITY_CACHE_KEY="packages_security_updates"
-
-# =============================================================================
-# Backend Detection
-# =============================================================================
-
-_DETECTED_BACKEND=""
-
-_detect_backend() {
-    [[ -n "$_DETECTED_BACKEND" ]] && {
-        printf '%s' "$_DETECTED_BACKEND"
-        return
-    }
-
+_invalidate_if_upgraded() {
+    local backends_str="$1"
     local backend
-    backend=$(get_option "backend")
-
-    case "$backend" in
-    brew | yay | apt | dnf | yum | pacman)
-        if has_cmd "$backend"; then
-            _DETECTED_BACKEND="$backend"
-            printf '%s' "$backend"
-            return
-        fi
-        ;;
-    esac
-
-    # Auto-detect in priority order
-    for pm in brew yay dnf apt yum pacman; do
-        if has_cmd "$pm"; then
-            _DETECTED_BACKEND="$pm"
-            printf '%s' "$pm"
-            return
-        fi
+    for backend in $backends_str; do
+        _invalidate_backend_cache "$backend"
     done
+}
 
-    printf ''
+# =============================================================================
+# Cache Keys (per-backend)
+# =============================================================================
+
+_pkg_cache_key()          { printf 'packages_updates_%s' "$1"; }
+_pkg_security_cache_key() { printf 'packages_security_updates_%s' "$1"; }
+
+# =============================================================================
+# Backend Detection (multi-backend)
+# =============================================================================
+
+_DETECTED_BACKENDS=""
+
+_detect_backends() {
+    [[ -n "$_DETECTED_BACKENDS" ]] && { printf '%s' "$_DETECTED_BACKENDS"; return; }
+
+    # Mode 1 — explicit list: @powerkit_packages_backends "brew,zb"
+    local configured
+    configured=$(get_option "backends")
+    if [[ -n "$configured" ]]; then
+        local active=()
+        IFS=',' read -ra requested <<< "$configured"
+        local b
+        for b in "${requested[@]}"; do
+            b="$(trim "$b")"
+            [[ -n "$b" ]] && has_cmd "$b" && active+=("$b")
+        done
+        _DETECTED_BACKENDS="${active[*]}"
+        printf '%s' "$_DETECTED_BACKENDS"
+        return
+    fi
+
+    # Mode 2 — legacy single: @powerkit_packages_backend "brew"
+    local single
+    single=$(get_option "backend")
+    if [[ "$single" != "auto" ]]; then
+        if has_cmd "$single"; then
+            _DETECTED_BACKENDS="$single"
+        fi
+        printf '%s' "$_DETECTED_BACKENDS"
+        return
+    fi
+
+    # Mode 3 — auto: detect ALL available package managers
+    local detected=()
+    local pm
+    for pm in brew zb port yay pacman pamac dnf apt yum \
+              nix-env mise flatpak zypper emerge apk pkg snap; do
+        has_cmd "$pm" && detected+=("$pm")
+    done
+    _DETECTED_BACKENDS="${detected[*]}"
+    printf '%s' "$_DETECTED_BACKENDS"
 }
 
 # =============================================================================
@@ -226,7 +262,8 @@ _count_updates_brew() {
 
     local brew_args=("outdated")
     if [[ -n "$brew_opts" ]]; then
-        IFS=',' read -ra opts <<<"$brew_opts"
+        IFS=',' read -ra opts <<< "$brew_opts"
+        local opt
         for opt in "${opts[@]}"; do
             brew_args+=("$(trim "$opt")")
         done
@@ -239,6 +276,17 @@ _count_updates_brew() {
         count=$(printf '%s' "$outdated" | grep -c .)
     fi
     printf '%s' "$count"
+}
+
+_count_updates_zb() {
+    local outdated count
+    outdated=$(_timeout_pkg command zb outdated 2>/dev/null || echo '')
+    if [[ -z "$outdated" ]]; then
+        count=0
+    else
+        count=$(printf '%s' "$outdated" | grep -c .)
+    fi
+    printf '%s' "${count:-0}"
 }
 
 _count_updates_yay() {
@@ -276,6 +324,84 @@ _count_updates_pacman() {
     _timeout_pkg command pacman -Qu 2>/dev/null | wc -l | tr -d ' '
 }
 
+_count_updates_nix-env() {
+    # nix-env -qc: '<' = newer version available, '=' = up to date, '>' = newer than channel
+    local count
+    count=$(_timeout_pkg command nix-env -qc 2>/dev/null | grep -c ' < ' || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_mise() {
+    local count
+    count=$(_timeout_pkg command mise outdated 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_flatpak() {
+    local count
+    count=$(_timeout_pkg command flatpak remote-ls --updates 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_zypper() {
+    # zypper lu: update lines start with 'v' (version) or 'i' (install candidate)
+    local count
+    count=$(_timeout_pkg command zypper --non-interactive lu 2>/dev/null \
+        | grep -c '^v\|^i' || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_emerge() {
+    local count
+    if has_cmd "eix"; then
+        # eix is much faster than emerge -p
+        count=$(_timeout_pkg command eix -u --only-names 2>/dev/null | grep -c . || echo 0)
+    else
+        # Fallback: emerge -puDN can be slow (30-60s); the 1h TTL cache mitigates this
+        count=$(_timeout_pkg command emerge -puDN --quiet @world 2>/dev/null \
+            | grep -c '^\[ebuild' || echo 0)
+    fi
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_apk() {
+    local count
+    count=$(_timeout_pkg command apk list -u 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_pkg() {
+    # FreeBSD: pkg version -l '<' lists packages with an older installed version
+    local count
+    count=$(_timeout_pkg command pkg version -l '<' 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_snap() {
+    # snap refresh --list: first line is a header; skip it
+    local outdated count
+    outdated=$(_timeout_pkg command snap refresh --list 2>/dev/null | tail -n +2 || echo '')
+    if [[ -z "$outdated" ]]; then
+        count=0
+    else
+        count=$(printf '%s' "$outdated" | grep -c .)
+    fi
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_pamac() {
+    local count
+    count=$(_timeout_pkg command pamac checkupdates --quiet 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
+_count_updates_port() {
+    # MacPorts: port outdated lists outdated ports, one per line
+    local count
+    count=$(_timeout_pkg command port outdated 2>/dev/null | grep -c . || echo 0)
+    printf '%s' "${count:-0}"
+}
+
 _count_security_updates() {
     local backend="$1"
 
@@ -297,50 +423,84 @@ _count_security_updates() {
 # =============================================================================
 
 plugin_collect() {
-    local backend count security_count packages_cache_ttl display cached
-    backend=$(_detect_backend)
+    local backends_str packages_cache_ttl display
+    backends_str=$(_detect_backends)
 
-    [[ -z "$backend" ]] && {
+    [[ -z "$backends_str" ]] && {
         plugin_data_set "update_count" "0"
         return 0
     }
 
-    # Invalidate cache if packages were upgraded (checks log/dir modification times)
-    _invalidate_if_upgraded "$backend"
+    # Invalidate per-backend caches when packages were upgraded
+    _invalidate_if_upgraded "$backends_str"
 
-    # Check packages cache (long TTL for expensive brew outdated operation)
     packages_cache_ttl=$(get_option "packages_cache_ttl")
     display=$(get_option "update_display")
-    cached=$(cache_get "$_PACKAGES_CACHE_KEY" "$packages_cache_ttl" 2>/dev/null)
 
-    if [[ -n "$cached" ]]; then
-        plugin_data_set "update_count" "$cached"
-        plugin_data_set "backend" "$backend"
-    else
-        # No cache - get fresh count (expensive operation)
-        case "$backend" in
-        brew) count=$(_count_updates_brew) ;;
-        yay) count=$(_count_updates_yay) ;;
-        apt) count=$(_count_updates_apt) ;;
-        dnf) count=$(_count_updates_dnf) ;;
-        yum) count=$(_count_updates_yum) ;;
-        pacman) count=$(_count_updates_pacman) ;;
-        *) count=0 ;;
-        esac
+    local total=0
+    local -a backends
+    read -ra backends <<< "$backends_str"
 
-        count="${count:-0}"
-        cache_set "$_PACKAGES_CACHE_KEY" "$count"
-        plugin_data_set "update_count" "$count"
-        plugin_data_set "backend" "$backend"
-    fi
+    for backend in "${backends[@]}"; do
+        local cache_key count cached
+        cache_key=$(_pkg_cache_key "$backend")
+        cached=$(cache_get "$cache_key" "$packages_cache_ttl" 2>/dev/null)
+
+        if [[ -n "$cached" ]]; then
+            count="$cached"
+        else
+            # Dispatch to per-backend implementation.
+            # nix-env has a hyphen, so we cannot use a simple function name dispatch —
+            # we handle it explicitly in the case statement.
+            case "$backend" in
+            brew)    count=$(_count_updates_brew) ;;
+            zb)      count=$(_count_updates_zb) ;;
+            yay)     count=$(_count_updates_yay) ;;
+            apt)     count=$(_count_updates_apt) ;;
+            dnf)     count=$(_count_updates_dnf) ;;
+            yum)     count=$(_count_updates_yum) ;;
+            pacman)  count=$(_count_updates_pacman) ;;
+            nix-env) count=$(_count_updates_nix-env) ;;
+            mise)    count=$(_count_updates_mise) ;;
+            flatpak) count=$(_count_updates_flatpak) ;;
+            zypper)  count=$(_count_updates_zypper) ;;
+            emerge)  count=$(_count_updates_emerge) ;;
+            apk)     count=$(_count_updates_apk) ;;
+            pkg)     count=$(_count_updates_pkg) ;;
+            snap)    count=$(_count_updates_snap) ;;
+            pamac)   count=$(_count_updates_pamac) ;;
+            port)    count=$(_count_updates_port) ;;
+            *)       count=0 ;;
+            esac
+
+            count="${count:-0}"
+            cache_set "$cache_key" "$count"
+        fi
+
+        (( total += count ))
+    done
+
+    plugin_data_set "update_count" "$total"
+    plugin_data_set "backends"     "$backends_str"
 
     [[ "$display" == "total" ]] && return 0
-    security_count=$(cache_get "$_PACKAGES_SECURITY_CACHE_KEY" "$packages_cache_ttl" 2>/dev/null)
-    if [[ -z "$security_count" ]]; then
-        security_count=$(_count_security_updates "$backend") || security_count=""
-        [[ -n "$security_count" ]] && cache_set "$_PACKAGES_SECURITY_CACHE_KEY" "$security_count"
-    fi
-    plugin_data_set "security_update_count" "$security_count"
+
+    # Security update counts (only for backends that support it: apt, dnf, yum)
+    local sec_total=0
+    for backend in "${backends[@]}"; do
+        local sec_key sec_count sec_cached
+        sec_key=$(_pkg_security_cache_key "$backend")
+        sec_cached=$(cache_get "$sec_key" "$packages_cache_ttl" 2>/dev/null)
+
+        if [[ -n "$sec_cached" ]]; then
+            sec_count="$sec_cached"
+        else
+            sec_count=$(_count_security_updates "$backend") || sec_count=""
+            [[ -n "$sec_count" ]] && cache_set "$sec_key" "$sec_count"
+        fi
+        (( sec_total += ${sec_count:-0} ))
+    done
+    plugin_data_set "security_update_count" "$sec_total"
 }
 
 plugin_render() {


### PR DESCRIPTION
Replaces single-backend detection with a multi-backend aggregation model
that detects all available package managers and sums their update counts.

New backends (11):
  - zb (zerobrew) - macOS Homebrew-compatible alternative
  - nix-env - NixOS and any platform using Nix
  - mise - cross-platform tool version manager
  - flatpak - Linux Flatpak store
  - zypper - openSUSE/SLES
  - emerge - Gentoo (prefers eix for performance, falls back to emerge -p)
  - apk - Alpine Linux
  - pkg - FreeBSD
  - snap - Ubuntu Snap Store
  - pamac - Manjaro (AUR/pacman frontend)
  - port - macOS MacPorts

Architecture changes:
  - _detect_backend() replaced by _detect_backends() (space-separated list)
  - Cache keys are now per-backend: packages_updates_<backend>
  - _invalidate_if_upgraded() iterates over all backends individually
  - Cache invalidation extended to zb (/opt/zerobrew) and port (/opt/local)
  - Security update counts aggregated across all supporting backends

New option:
  - backends (string): explicit comma-separated list, e.g. 'brew,zb'
    Overrides the legacy 'backend' enum option when set.

Behavior in auto mode (breaking):
  Previously stopped at the first detected package manager.
  Now detects ALL available managers and shows the summed total.
  Legacy single-backend mode preserved via: set -g @powerkit_packages_backend brew## Summary

<!-- 1-3 bullet points describing what changed and why -->

## Changes

<!-- List of changes with their types (feat/fix/chore/refactor/etc.) -->

- **`<type>(<scope>): <subject>`** - short description
  - Detail 1
  - Detail 2

## Test Plan

<!-- How was this validated? -->

- [ ] `bash tests/run_all_tests.sh` — passes
- [ ] `tests/test_shellcheck.sh` — 0 warnings
- [ ] `pre-commit validate-config` — passes
- [ ] CI matrix (ubuntu + macOS) — passes
- [ ] Manual smoke test of affected plugins

## Verification log

<!-- Paste command output here for reviewers -->

```text
$ bash tests/run_all_tests.sh
... (paste relevant output)

$ shellcheck -S warning bin/ scripts/ tests/
... (paste relevant output)
```

## Out of scope / known follow-up

<!-- Anything discovered but intentionally not fixed in this PR -->

## Checklist

- [ ] Branch is up-to-date with `main`
- [ ] Commit messages follow Conventional Commits
- [ ] No `Co-Authored-By` lines
- [ ] No emoji in commit messages or PR title
- [ ] All tests pass locally
- [ ] No new shellcheck warnings introduced
- [ ] Plugin contract still respected (data only, no UI logic)
- [ ] Cross-platform impact considered (Linux + macOS)