### PR TITLE
feat(theme): add last-horizon, lumon, lupine, retro82 and solitude themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## The Ultimate tmux Status Bar Framework
 
-48 Plugins • 43 Themes • Infinite Possibilities
+48 Plugins • 48 Themes • Infinite Possibilities
 
 [![Version](https://img.shields.io/github/v/release/fabioluciano/tmux-powerkit?style=for-the-badge&logo=github&logoColor=white)](https://github.com/fabioluciano/tmux-powerkit/releases)
 [![License](https://img.shields.io/github/license/fabioluciano/tmux-powerkit?style=for-the-badge)](LICENSE)
@@ -33,7 +33,7 @@ Transform your tmux status bar into a powerful, beautiful, and intelligent comma
 
 ### 🎨 **Beautiful by Default**
 
-Choose from **43 carefully crafted themes** with **71 variants** including Catppuccin, Dracula, Monokai, Nord, Tokyo Night, and more. Every theme supports automatic color variants (light/lighter/dark/darker) for perfect contrast.
+Choose from **48 carefully crafted themes** with **75 variants** including Catppuccin, Dracula, Monokai, Nord, Tokyo Night, and more. Every theme supports automatic color variants (light/lighter/dark/darker) for perfect contrast.
 
 ### ⚡ **Blazingly Fast**
 
@@ -168,84 +168,84 @@ set -g @powerkit_transparent "true"
 
 Monitor every aspect of your system in real-time:
 
-| Plugin | Description | Highlights |
-| -------- | ------------- | ----------- |
-| `battery` | Battery level with charge state | Shows charging status, time remaining, health indicators |
-| `cpu` | CPU usage with per-core support | Thresholds, multi-core detection, platform-specific |
-| `memory` | RAM usage and availability | Multiple formats (percentage, usage, available) |
-| `swap` | Swap memory usage | Cross-platform, threshold alerts, multiple display formats |
-| `disk` | Disk usage by mount point | Configurable thresholds, multiple drives |
-| `loadavg` | System load average | 1/5/15 minute averages, per-core normalization |
-| `temperature` | CPU temperature | macOS (osx-cpu-temp), Linux (hwmon) |
-| `fan` | Fan speed monitoring | Dell SMM, ThinkPad, generic hwmon, macOS |
-| `gpu` | GPU utilization | NVIDIA, AMD, Intel, macOS support |
-| `iops` | Disk I/O operations | Read/write operations per second |
-| `brightness` | Screen brightness | Linux only (sysfs, brightnessctl, light, xbacklight) |
-| `uptime` | System uptime | Human-readable format |
-| `hostname` | System hostname | Color-coded by environment |
-| `topproc` | Top CPU process | Process name and usage %, threshold alerts |
-| `sysstatus` | Aggregated system health badge | Combined OK/WARN/CRIT across CPU, memory, disk, temperature |
+| Plugin        | Description                     | Highlights                                                  |
+| ------------- | ------------------------------- | ----------------------------------------------------------- |
+| `battery`     | Battery level with charge state | Shows charging status, time remaining, health indicators    |
+| `cpu`         | CPU usage with per-core support | Thresholds, multi-core detection, platform-specific         |
+| `memory`      | RAM usage and availability      | Multiple formats (percentage, usage, available)             |
+| `swap`        | Swap memory usage               | Cross-platform, threshold alerts, multiple display formats  |
+| `disk`        | Disk usage by mount point       | Configurable thresholds, multiple drives                    |
+| `loadavg`     | System load average             | 1/5/15 minute averages, per-core normalization              |
+| `temperature` | CPU temperature                 | macOS (osx-cpu-temp), Linux (hwmon)                         |
+| `fan`         | Fan speed monitoring            | Dell SMM, ThinkPad, generic hwmon, macOS                    |
+| `gpu`         | GPU utilization                 | NVIDIA, AMD, Intel, macOS support                           |
+| `iops`        | Disk I/O operations             | Read/write operations per second                            |
+| `brightness`  | Screen brightness               | Linux only (sysfs, brightnessctl, light, xbacklight)        |
+| `uptime`      | System uptime                   | Human-readable format                                       |
+| `hostname`    | System hostname                 | Color-coded by environment                                  |
+| `topproc`     | Top CPU process                 | Process name and usage %, threshold alerts                  |
+| `sysstatus`   | Aggregated system health badge  | Combined OK/WARN/CRIT across CPU, memory, disk, temperature |
 
 ### 🌐 Network (8 plugins)
 
 Stay connected and informed:
 
-| Plugin | Description | Features |
-| -------- | ------------- | ---------- |
-| `netspeed` | Upload/download speed | Real-time bandwidth monitoring |
-| `wifi` | WiFi SSID + signal strength | Signal quality indicators |
-| `vpn` | VPN connection status | Detects active VPN tunnels |
-| `ping` | Network latency | Configurable host, threshold alerts |
-| `external_ip` | Public IP address | Cached with configurable TTL |
-| `ssh` | SSH session indicator | Shows when connected via SSH |
-| `weather` | Weather from wttr.in | Location-based, customizable format |
+| Plugin         | Description                  | Features                                        |
+| -------------- | ---------------------------- | ----------------------------------------------- |
+| `netspeed`     | Upload/download speed        | Real-time bandwidth monitoring                  |
+| `wifi`         | WiFi SSID + signal strength  | Signal quality indicators                       |
+| `vpn`          | VPN connection status        | Detects active VPN tunnels                      |
+| `ping`         | Network latency              | Configurable host, threshold alerts             |
+| `external_ip`  | Public IP address            | Cached with configurable TTL                    |
+| `ssh`          | SSH session indicator        | Shows when connected via SSH                    |
+| `weather`      | Weather from wttr.in         | Location-based, customizable format             |
 | `connectivity` | Internet connectivity status | Online/offline indicator, configurable endpoint |
 
 ### 🎵 Media (6 plugins)
 
 Control your media experience:
 
-| Plugin | Description | Platform |
-| -------- | ------------- | ---------- |
-| `volume` | System volume level | macOS only |
-| `nowplaying` | Current music track | Music.app, Spotify (macOS) |
-| `audiodevices` | Active audio output device | macOS (SwitchAudioSource) |
-| `camera` | Camera usage indicator | macOS (lsof) |
-| `microphone` | Microphone mute status | macOS (osascript) |
-| `bluetooth` | Bluetooth status + devices | macOS (blueutil), Linux (bluetoothctl) |
+| Plugin         | Description                | Platform                               |
+| -------------- | -------------------------- | -------------------------------------- |
+| `volume`       | System volume level        | macOS only                             |
+| `nowplaying`   | Current music track        | Music.app, Spotify (macOS)             |
+| `audiodevices` | Active audio output device | macOS (SwitchAudioSource)              |
+| `camera`       | Camera usage indicator     | macOS (lsof)                           |
+| `microphone`   | Microphone mute status     | macOS (osascript)                      |
+| `bluetooth`    | Bluetooth status + devices | macOS (blueutil), Linux (bluetoothctl) |
 
 ### 💻 Development (13 plugins)
 
 Supercharge your development workflow:
 
-| Plugin | Description | Features |
-| -------- | ------------- | ---------- |
-| `git` | Git branch + status | Modified files, branch info, repo state |
-| `github` | GitHub notifications | PRs, issues, notifications (gh CLI) |
-| `gitlab` | GitLab merge requests | MRs, todos (glab CLI) |
-| `bitbucket` | Bitbucket pull requests | PR count via API |
-| `jira` | Jira assigned issues | Issue count via API |
-| `kubernetes` | K8s context + namespace | Current context and namespace |
-| `terraform` | Terraform workspace | Active workspace indicator |
-| `cloud` | Cloud provider profile | AWS/Azure/GCP active profile |
-| `cloudstatus` | Cloud service status | Service health monitoring |
-| `yadm` | yadm dotfile status | Modified/untracked dotfiles, ahead/behind counts |
-| `chezmoi` | chezmoi dotfile status | Pending dotfile changes |
-| `packages` | Pending system updates | brew, apt, yum, pacman support |
-| `docker` | Docker or Podman containers | Running, stopped, and unhealthy container counts |
+| Plugin        | Description                 | Features                                         |
+| ------------- | --------------------------- | ------------------------------------------------ |
+| `git`         | Git branch + status         | Modified files, branch info, repo state          |
+| `github`      | GitHub notifications        | PRs, issues, notifications (gh CLI)              |
+| `gitlab`      | GitLab merge requests       | MRs, todos (glab CLI)                            |
+| `bitbucket`   | Bitbucket pull requests     | PR count via API                                 |
+| `jira`        | Jira assigned issues        | Issue count via API                              |
+| `kubernetes`  | K8s context + namespace     | Current context and namespace                    |
+| `terraform`   | Terraform workspace         | Active workspace indicator                       |
+| `cloud`       | Cloud provider profile      | AWS/Azure/GCP active profile                     |
+| `cloudstatus` | Cloud service status        | Service health monitoring                        |
+| `yadm`        | yadm dotfile status         | Modified/untracked dotfiles, ahead/behind counts |
+| `chezmoi`     | chezmoi dotfile status      | Pending dotfile changes                          |
+| `packages`    | Pending system updates      | brew, apt, yum, pacman support                   |
+| `docker`      | Docker or Podman containers | Running, stopped, and unhealthy container counts |
 
 ### ⏰ Productivity (6 plugins)
 
 Boost your productivity:
 
-| Plugin | Description | Features |
-| -------- | ------------- | ---------- |
-| `datetime` | Date and time | 15 format presets, fully customizable |
-| `timezones` | Multiple timezones | Display multiple zones simultaneously |
-| `pomodoro` | Pomodoro timer | Work/break phases, keybindings |
-| `bitwarden` | Bitwarden vault status | Lock status, quick access |
-| `smartkey` | Custom environment variables | Display any env var or command output |
-| `appearance` | macOS appearance | Light/dark mode and theme switching |
+| Plugin       | Description                  | Features                              |
+| ------------ | ---------------------------- | ------------------------------------- |
+| `datetime`   | Date and time                | 15 format presets, fully customizable |
+| `timezones`  | Multiple timezones           | Display multiple zones simultaneously |
+| `pomodoro`   | Pomodoro timer               | Work/break phases, keybindings        |
+| `bitwarden`  | Bitwarden vault status       | Lock status, quick access             |
+| `smartkey`   | Custom environment variables | Display any env var or command output |
+| `appearance` | macOS appearance             | Light/dark mode and theme switching   |
 
 ### 💰 Financial (2 plugins)
 
@@ -260,7 +260,7 @@ Track your investments:
 
 ## 🎨 Themes
 
-PowerKit comes with **43 beautiful themes** and **71 variants**, each carefully designed for optimal readability and aesthetics
+PowerKit comes with **48 beautiful themes** and **75 variants**, each carefully designed for optimal readability and aesthetics
 
 ### Popular Themes
 
@@ -320,17 +320,17 @@ set -g @powerkit_theme_variant "dark"
 
 Choose from **9 beautiful separator styles** to customize your status bar appearance:
 
-| Style          | Right | Left  | Unicode   |
-| -------------- | ----- | ----- | --------- |
-| **normal**     |       |       | E0B0/E0B2 |
-| **rounded**    |       |       | E0B4/E0B6 |
-| **slant**      |       |       | E0B8/E0BA |
-| **slantup**    |       |       | E0BC/E0BE |
-| **trapezoid**  |       |       | E0C8/E0CA |
-| **flame**      |       |       | E0C0/E0C2 |
-| **pixel**      |       |       | E0C4/E0C6 |
-| **honeycomb**  |       |       | E0CC/E0CD |
-| **none**       | -     | -     | -         |
+| Style         | Right | Left | Unicode   |
+| ------------- | ----- | ---- | --------- |
+| **normal**    |       |      | E0B0/E0B2 |
+| **rounded**   |       |      | E0B4/E0B6 |
+| **slant**     |       |      | E0B8/E0BA |
+| **slantup**   |       |      | E0BC/E0BE |
+| **trapezoid** |       |      | E0C8/E0CA |
+| **flame**     |       |      | E0C0/E0C2 |
+| **pixel**     |       |      | E0C4/E0C6 |
+| **honeycomb** |       |      | E0CC/E0CD |
+| **none**      | -     | -    | -         |
 
 ```bash
 # Configure separator style
@@ -670,17 +670,17 @@ The system automatically generates **6 color variants** (light/lighter/lightest/
 
 ## 📚 Complete Documentation
 
-| Resource | Description |
-| ---------- | ------------- |
-| [**Installation Guide**](https://github.com/fabioluciano/tmux-powerkit/wiki/Installation) | Detailed setup instructions |
-| [**Quick Start**](https://github.com/fabioluciano/tmux-powerkit/wiki/Quick-Start) | Get started in 5 minutes |
-| [**Configuration Reference**](https://github.com/fabioluciano/tmux-powerkit/wiki/Configuration) | All configuration options explained |
-| [**Plugin Documentation**](https://github.com/fabioluciano/tmux-powerkit/wiki/Home#plugins) | Detailed docs for all available plugins |
-| [**Theme Gallery**](https://github.com/fabioluciano/tmux-powerkit/wiki/Themes) | Preview all themes and variants |
-| [**Developing Plugins**](https://github.com/fabioluciano/tmux-powerkit/wiki/DevelopingPlugins) | Create your own plugins |
-| [**Developing Themes**](https://github.com/fabioluciano/tmux-powerkit/wiki/DevelopingThemes) | Create custom themes |
-| [**Architecture**](https://github.com/fabioluciano/tmux-powerkit/wiki/Architecture) | Understanding the contract system |
-| [**API Reference**](https://github.com/fabioluciano/tmux-powerkit/wiki/API-Reference) | Core APIs and utilities |
+| Resource                                                                                        | Description                             |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
+| [**Installation Guide**](https://github.com/fabioluciano/tmux-powerkit/wiki/Installation)       | Detailed setup instructions             |
+| [**Quick Start**](https://github.com/fabioluciano/tmux-powerkit/wiki/Quick-Start)               | Get started in 5 minutes                |
+| [**Configuration Reference**](https://github.com/fabioluciano/tmux-powerkit/wiki/Configuration) | All configuration options explained     |
+| [**Plugin Documentation**](https://github.com/fabioluciano/tmux-powerkit/wiki/Home#plugins)     | Detailed docs for all available plugins |
+| [**Theme Gallery**](https://github.com/fabioluciano/tmux-powerkit/wiki/Themes)                  | Preview all themes and variants         |
+| [**Developing Plugins**](https://github.com/fabioluciano/tmux-powerkit/wiki/DevelopingPlugins)  | Create your own plugins                 |
+| [**Developing Themes**](https://github.com/fabioluciano/tmux-powerkit/wiki/DevelopingThemes)    | Create custom themes                    |
+| [**Architecture**](https://github.com/fabioluciano/tmux-powerkit/wiki/Architecture)             | Understanding the contract system       |
+| [**API Reference**](https://github.com/fabioluciano/tmux-powerkit/wiki/API-Reference)           | Core APIs and utilities                 |
 
 ### 📋 Complete Options Reference
 
@@ -707,10 +707,10 @@ Use this file as a reference or copy the options you need to your `~/.tmux.conf`
 
 ### Bash Version Features Used
 
-| Version | Features Used |
-| --------- | -------------- |
-| 5.0+ | `$EPOCHSECONDS`, `$EPOCHREALTIME`, `${var,,}`, `${var^^}` |
-| 5.1+ | `assoc_expand_once` (performance optimization) |
+| Version | Features Used                                             |
+| ------- | --------------------------------------------------------- |
+| 5.0+    | `$EPOCHSECONDS`, `$EPOCHREALTIME`, `${var,,}`, `${var^^}` |
+| 5.1+    | `assoc_expand_once` (performance optimization)            |
 
 ### Platform Support
 

--- a/src/themes/last-horizon/dark.sh
+++ b/src/themes/last-horizon/dark.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Theme: Last Horizon - Dark
+# Description: Calm dark theme inspired by the Last Horizon palette
+# Source: https://github.com/neapsix/last-horizon
+# =============================================================================
+
+declare -gA THEME_COLORS=(
+    # =========================================================================
+    # CORE (terminal background - used for transparent mode separators)
+    # =========================================================================
+    [background]="#0c0b0c"               # background
+
+    # =========================================================================
+    # STATUS BAR
+    # =========================================================================
+    [statusbar-bg]="#0c0b0c"             # background
+    [statusbar-fg]="#e2dddc"             # bright_foreground
+
+    # =========================================================================
+    # SESSION (status-left)
+    # =========================================================================
+    [session-bg]="#b59790"               # accent/blue
+    [session-fg]="#0c0b0c"               # background
+    [session-prefix-bg]="#6B5E73"        # yellow
+    [session-copy-bg]="#87a9b0"          # green
+    [session-search-bg]="#6B5E73"        # yellow
+    [session-command-bg]="#c4d8e2"       # magenta
+
+    # =========================================================================
+    # WINDOW (active)
+    # =========================================================================
+    [window-active-base]="#c4d8e2"       # magenta (distinctive)
+
+    # =========================================================================
+    # WINDOW (inactive)
+    # =========================================================================
+    [window-inactive-base]="#584e51"     # muted
+
+    # =========================================================================
+    # WINDOW STATE (activity, bell, zoomed)
+    # =========================================================================
+    [window-zoomed-bg]="#87a9b0"         # green
+
+    # =========================================================================
+    # PANE
+    # =========================================================================
+    [pane-border-active]="#b59790"       # accent/blue
+    [pane-border-inactive]="#584e51"     # muted
+
+    # =========================================================================
+    # STATUS COLORS (health/state-based for plugins)
+    # =========================================================================
+    [ok-base]="#584e51"                  # muted (distinct from statusbar-bg)
+    [good-base]="#87a9b0"                # green
+    [info-base]="#a5a0b6"                # cyan
+    [warning-base]="#6B5E73"             # yellow
+    [error-base]="#c38b7b"               # red
+    [disabled-base]="#584e51"            # muted
+
+    # =========================================================================
+    # MESSAGE COLORS
+    # =========================================================================
+    [message-bg]="#0c0b0c"               # background
+    [message-fg]="#e2dddc"               # bright_foreground
+
+    # =========================================================================
+    # POPUP & MENU
+    # =========================================================================
+    [popup-bg]="#0c0b0c"                 # Popup background
+    [popup-fg]="#cfd3cd"                 # Popup foreground
+    [popup-border]="#b59790"             # Popup border
+    [menu-bg]="#0c0b0c"                  # Menu background
+    [menu-fg]="#cfd3cd"                  # Menu foreground
+    [menu-selected-bg]="#b59790"         # Menu selected background
+    [menu-selected-fg]="#0c0b0c"         # Menu selected foreground
+    [menu-border]="#b59790"              # Menu border
+)
+
+export THEME_COLORS

--- a/src/themes/lumon/dark.sh
+++ b/src/themes/lumon/dark.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Theme: Lumon - Dark
+# Description: Cool blue-toned dark theme inspired by Lumon Industries
+# Source: https://github.com/ajh17/lumon
+# =============================================================================
+
+declare -gA THEME_COLORS=(
+    # =========================================================================
+    # CORE (terminal background - used for transparent mode separators)
+    # =========================================================================
+    [background]="#16242d"               # background
+
+    # =========================================================================
+    # STATUS BAR
+    # =========================================================================
+    [statusbar-bg]="#16242d"             # background
+    [statusbar-fg]="#f2fcff"             # bright_foreground
+
+    # =========================================================================
+    # SESSION (status-left)
+    # =========================================================================
+    [session-bg]="#6fb8e3"               # blue/active_tab_background
+    [session-fg]="#16242d"               # background
+    [session-prefix-bg]="#6fa4c9"        # yellow
+    [session-copy-bg]="#5e95bc"          # green
+    [session-search-bg]="#8bc9eb"        # accent
+    [session-command-bg]="#8bc9eb"       # magenta
+
+    # =========================================================================
+    # WINDOW (active)
+    # =========================================================================
+    [window-active-base]="#8bc9eb"       # accent (distinctive)
+
+    # =========================================================================
+    # WINDOW (inactive)
+    # =========================================================================
+    [window-inactive-base]="#304860"     # muted
+
+    # =========================================================================
+    # WINDOW STATE (activity, bell, zoomed)
+    # =========================================================================
+    [window-zoomed-bg]="#5e95bc"         # green
+
+    # =========================================================================
+    # PANE
+    # =========================================================================
+    [pane-border-active]="#6fb8e3"       # blue
+    [pane-border-inactive]="#304860"     # muted
+
+    # =========================================================================
+    # STATUS COLORS (health/state-based for plugins)
+    # =========================================================================
+    [ok-base]="#304860"                  # muted (distinct from statusbar-bg)
+    [good-base]="#5e95bc"                # green
+    [info-base]="#b4e4f6"                # cyan
+    [warning-base]="#6fa4c9"             # yellow
+    [error-base]="#73a6cb"               # bright_red
+    [disabled-base]="#243d56"            # selection
+
+    # =========================================================================
+    # MESSAGE COLORS
+    # =========================================================================
+    [message-bg]="#16242d"               # background
+    [message-fg]="#f2fcff"               # bright_foreground
+
+    # =========================================================================
+    # POPUP & MENU
+    # =========================================================================
+    [popup-bg]="#16242d"                 # Popup background
+    [popup-fg]="#d6e2ee"                 # Popup foreground
+    [popup-border]="#6fb8e3"             # Popup border
+    [menu-bg]="#16242d"                  # Menu background
+    [menu-fg]="#d6e2ee"                  # Menu foreground
+    [menu-selected-bg]="#6fb8e3"         # Menu selected background
+    [menu-selected-fg]="#16242d"         # Menu selected foreground
+    [menu-border]="#6fb8e3"              # Menu border
+)
+
+export THEME_COLORS

--- a/src/themes/lupine/light.sh
+++ b/src/themes/lupine/light.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Theme: Lupine - Light
+# Description: Clean light theme inspired by the Lupine palette
+# Source: https://github.com/lupine-dev
+# =============================================================================
+
+declare -gA THEME_COLORS=(
+    # =========================================================================
+    # CORE (terminal background - used for transparent mode separators)
+    # =========================================================================
+    [background]="#fafafa"               # background
+
+    # =========================================================================
+    # STATUS BAR
+    # =========================================================================
+    [statusbar-bg]="#fafafa"             # background
+    [statusbar-fg]="#212121"             # foreground
+
+    # =========================================================================
+    # SESSION (status-left)
+    # =========================================================================
+    [session-bg]="#3264eb"               # accent/blue
+    [session-fg]="#fafafa"               # background (contrast)
+    [session-prefix-bg]="#026fde"        # yellow
+    [session-copy-bg]="#4a2fd0"          # green
+    [session-search-bg]="#3264eb"        # accent
+    [session-command-bg]="#8a4ad7"       # magenta
+
+    # =========================================================================
+    # WINDOW (active)
+    # =========================================================================
+    [window-active-base]="#8a4ad7"       # magenta (distinctive)
+
+    # =========================================================================
+    # WINDOW (inactive)
+    # =========================================================================
+    [window-inactive-base]="#dedede"     # darker_background (lighter contrast)
+
+    # =========================================================================
+    # WINDOW STATE (activity, bell, zoomed)
+    # =========================================================================
+    [window-zoomed-bg]="#0c67de"         # cyan
+
+    # =========================================================================
+    # PANE
+    # =========================================================================
+    [pane-border-active]="#3264eb"       # accent/blue
+    [pane-border-inactive]="#d0d0d0"     # selection
+
+    # =========================================================================
+    # STATUS COLORS (health/state-based for plugins)
+    # =========================================================================
+    [ok-base]="#d0d0d0"                  # selection (distinct from statusbar-bg)
+    [good-base]="#4a2fd0"                # green
+    [info-base]="#0c67de"                # cyan
+    [warning-base]="#026fde"             # yellow
+    [error-base]="#c900c4"               # red
+    [disabled-base]="#9e9e9e"            # muted
+
+    # =========================================================================
+    # MESSAGE COLORS
+    # =========================================================================
+    [message-bg]="#fafafa"               # background
+    [message-fg]="#212121"               # foreground
+
+    # =========================================================================
+    # POPUP & MENU
+    # =========================================================================
+    [popup-bg]="#fafafa"                 # Popup background
+    [popup-fg]="#212121"                 # Popup foreground
+    [popup-border]="#3264eb"             # Popup border
+    [menu-bg]="#fafafa"                  # Menu background
+    [menu-fg]="#212121"                  # Menu foreground
+    [menu-selected-bg]="#3264eb"         # Menu selected background
+    [menu-selected-fg]="#fafafa"         # Menu selected foreground
+    [menu-border]="#3264eb"              # Menu border
+)
+
+export THEME_COLORS

--- a/src/themes/retro82/dark.sh
+++ b/src/themes/retro82/dark.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Theme: Retro 82 - Dark
+# Description: Retro-teal dark theme inspired by the Retro 82 palette
+# Source: https://github.com/retro82/retro82
+# =============================================================================
+
+declare -gA THEME_COLORS=(
+    # =========================================================================
+    # CORE (terminal background - used for transparent mode separators)
+    # =========================================================================
+    [background]="#05182e"               # background
+
+    # =========================================================================
+    # STATUS BAR
+    # =========================================================================
+    [statusbar-bg]="#05182e"             # background
+    [statusbar-fg]="#f6dcac"             # bright_foreground
+
+    # =========================================================================
+    # SESSION (status-left)
+    # =========================================================================
+    [session-bg]="#faa968"               # accent/orange
+    [session-fg]="#05182e"               # background
+    [session-prefix-bg]="#e97b3c"        # yellow
+    [session-copy-bg]="#028391"          # green
+    [session-search-bg]="#f85525"        # red
+    [session-command-bg]="#8cbfb8"       # cyan
+
+    # =========================================================================
+    # WINDOW (active)
+    # =========================================================================
+    [window-active-base]="#faa968"       # accent (distinctive)
+
+    # =========================================================================
+    # WINDOW (inactive)
+    # =========================================================================
+    [window-inactive-base]="#2a6b78"     # muted
+
+    # =========================================================================
+    # WINDOW STATE (activity, bell, zoomed)
+    # =========================================================================
+    [window-zoomed-bg]="#028391"         # green
+
+    # =========================================================================
+    # PANE
+    # =========================================================================
+    [pane-border-active]="#faa968"       # accent
+    [pane-border-inactive]="#2a6b78"     # muted
+
+    # =========================================================================
+    # STATUS COLORS (health/state-based for plugins)
+    # =========================================================================
+    [ok-base]="#2a6b78"                  # muted (distinct from statusbar-bg)
+    [good-base]="#028391"                # green
+    [info-base]="#8cbfb8"                # cyan
+    [warning-base]="#e97b3c"             # yellow
+    [error-base]="#f85525"               # red
+    [disabled-base]="#134e5a"            # selection
+
+    # =========================================================================
+    # MESSAGE COLORS
+    # =========================================================================
+    [message-bg]="#05182e"               # background
+    [message-fg]="#f6dcac"               # bright_foreground
+
+    # =========================================================================
+    # POPUP & MENU
+    # =========================================================================
+    [popup-bg]="#05182e"                 # Popup background
+    [popup-fg]="#a7c9c6"                 # Popup foreground
+    [popup-border]="#faa968"             # Popup border
+    [menu-bg]="#05182e"                  # Menu background
+    [menu-fg]="#a7c9c6"                  # Menu foreground
+    [menu-selected-bg]="#faa968"         # Menu selected background
+    [menu-selected-fg]="#05182e"         # Menu selected foreground
+    [menu-border]="#faa968"              # Menu border
+)
+
+export THEME_COLORS

--- a/src/themes/solitude/dark.sh
+++ b/src/themes/solitude/dark.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Theme: Solitude - Dark
+# Description: Serene monochrome dark theme inspired by the Solitude palette
+# Source: https://github.com/solitude-theme/solitude
+# =============================================================================
+
+declare -gA THEME_COLORS=(
+    # =========================================================================
+    # CORE (terminal background - used for transparent mode separators)
+    # =========================================================================
+    [background]="#101315"               # background
+
+    # =========================================================================
+    # STATUS BAR
+    # =========================================================================
+    [statusbar-bg]="#101315"             # background
+    [statusbar-fg]="#a5aeb4"             # bright_foreground
+
+    # =========================================================================
+    # SESSION (status-left)
+    # =========================================================================
+    [session-bg]="#798186"               # accent/blue
+    [session-fg]="#101315"               # background
+    [session-prefix-bg]="#c9c2b4"        # bright_yellow
+    [session-copy-bg]="#9fa5a9"          # green
+    [session-search-bg]="#de6145"        # bright_red
+    [session-command-bg]="#aeaeae"       # magenta
+
+    # =========================================================================
+    # WINDOW (active)
+    # =========================================================================
+    [window-active-base]="#798186"       # accent (distinctive)
+
+    # =========================================================================
+    # WINDOW (inactive)
+    # =========================================================================
+    [window-inactive-base]="#4b4e55"     # muted
+
+    # =========================================================================
+    # WINDOW STATE (activity, bell, zoomed)
+    # =========================================================================
+    [window-zoomed-bg]="#9fa5a9"         # green
+
+    # =========================================================================
+    # PANE
+    # =========================================================================
+    [pane-border-active]="#798186"       # accent
+    [pane-border-inactive]="#4b4e55"     # muted
+
+    # =========================================================================
+    # STATUS COLORS (health/state-based for plugins)
+    # =========================================================================
+    [ok-base]="#4b4e55"                  # muted (distinct from statusbar-bg)
+    [good-base]="#9fa5a9"                # green
+    [info-base]="#aeaeae"                # magenta
+    [warning-base]="#c9c2b4"             # bright_yellow
+    [error-base]="#de6145"               # bright_red
+    [disabled-base]="#343d41"            # selection
+
+    # =========================================================================
+    # MESSAGE COLORS
+    # =========================================================================
+    [message-bg]="#101315"               # background
+    [message-fg]="#a5aeb4"               # bright_foreground
+
+    # =========================================================================
+    # POPUP & MENU
+    # =========================================================================
+    [popup-bg]="#101315"                 # Popup background
+    [popup-fg]="#cacccc"                 # Popup foreground
+    [popup-border]="#798186"             # Popup border
+    [menu-bg]="#101315"                  # Menu background
+    [menu-fg]="#cacccc"                  # Menu foreground
+    [menu-selected-bg]="#798186"         # Menu selected background
+    [menu-selected-fg]="#101315"         # Menu selected foreground
+    [menu-border]="#798186"              # Menu border
+)
+
+export THEME_COLORS


### PR DESCRIPTION
## New Themes Added

- **Last Horizon** - dark variant
- **Lumon** - dark variant
- **Lupine** - light variant
- **Retro 82** - dark variant
- **Solitude** - dark variant

## Changes

- Added theme files for all five themes following the PowerKit color contract
- Updated README.md theme count (48 themes, 75 variants)
- Updated wiki (Themes.md, Home.md, powerkit-options.conf) with documentation for the new themes
- Removed retired preview images from the wiki to standardize theme documentation

Each theme maps its palette (background, accent, foreground, and health colors) to the PowerKit semantic color contract.