### PR TITLE
feat: performance improvements

### DIFF
--- a/bin/powerkit-icon
+++ b/bin/powerkit-icon
@@ -22,9 +22,9 @@ if declare -F plugin_check_dependencies &>/dev/null; then
     plugin_check_dependencies || exit 1
 fi
 
-declare -F plugin_declare_options &>/dev/null && plugin_declare_options
-
 _set_plugin_context "$name"
+
+declare -F plugin_declare_options &>/dev/null && plugin_declare_options
 
 plugin_data_clear
 plugin_collect || exit 1

--- a/bin/powerkit-render
+++ b/bin/powerkit-render
@@ -44,9 +44,7 @@ _render_cache_key() {
 _get_render_cache_ttl() {
     local interval
     interval=$(get_tmux_option "@powerkit_status_interval" "${POWERKIT_DEFAULT_STATUS_INTERVAL:-5}")
-    local battery_saver
-    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
-    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+    if is_battery_saver_active; then
         (( interval < 10 )) && interval=10
     fi
     printf '%s' "${interval:-5}"

--- a/bin/powerkit-render
+++ b/bin/powerkit-render
@@ -40,8 +40,17 @@ _render_cache_key() {
     printf 'rendered_%s__%s__%s' "$side" "$theme" "$variant"
 }
 
-# TTL for render cache (matches status-interval)
-_RENDER_CACHE_TTL=5
+# TTL for render cache (matches status-interval and adapts to battery saver)
+_get_render_cache_ttl() {
+    local interval
+    interval=$(get_tmux_option "@powerkit_status_interval" "${POWERKIT_DEFAULT_STATUS_INTERVAL:-5}")
+    local battery_saver
+    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
+    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+        (( interval < 10 )) && interval=10
+    fi
+    printf '%s' "${interval:-5}"
+}
 
 _render_lock_dir() {
     printf '%s/.render_lock' "$_CACHE_DIR"
@@ -200,8 +209,9 @@ cache_key=$(_render_cache_key "$side")
 
 # Fast path: return fresh cached render immediately
 # Note: cache can be empty when all conditional plugins are hidden
-if cache_valid "$cache_key" "$_RENDER_CACHE_TTL"; then
-    cached_render=$(cache_get "$cache_key" "$_RENDER_CACHE_TTL" 2>/dev/null) || cached_render=""
+render_ttl=$(_get_render_cache_ttl)
+if cache_valid "$cache_key" "$render_ttl"; then
+    cached_render=$(cache_get "$cache_key" "$render_ttl" 2>/dev/null) || cached_render=""
     printf '%s' "$cached_render"
     exit 0
 fi

--- a/src/contract/pane_contract.sh
+++ b/src/contract/pane_contract.sh
@@ -346,6 +346,8 @@ _pane_resolve_color() {
 #
 # The function is safe to call repeatedly - it only updates if there's a mismatch.
 sync_pane_flash_appearance() {
+    is_macos || return 0
+
     # platform.sh is always loaded before pane_contract.sh via bootstrap
     local system_appearance
     system_appearance=$(get_macos_appearance)

--- a/src/contract/plugin_contract.sh
+++ b/src/contract/plugin_contract.sh
@@ -240,11 +240,21 @@ require_cmd() {
 
 # Require at least one of the given commands
 # Usage: require_any_cmd "nvidia-smi" "rocm-smi" || return 1
+#        require_any_cmd "osx-cpu-temp" "smctemp" "istats" 1  # Optional (last arg is 1)
 require_any_cmd() {
+    local optional=0
+    local cmds=("$@")
+
+    # Check if last argument is the optional flag
+    if [[ ${#cmds[@]} -gt 0 && "${cmds[-1]}" == "1" ]]; then
+        optional=1
+        unset 'cmds[-1]'
+    fi
+
     local found=0
     local cmd
 
-    for cmd in "$@"; do
+    for cmd in "${cmds[@]}"; do
         if has_cmd "$cmd"; then
             found=1
             break
@@ -252,9 +262,15 @@ require_any_cmd() {
     done
 
     if [[ "$found" -eq 0 ]]; then
-        log_warn "plugin_contract" "None of the required commands found: $*"
-        _MISSING_DEPS+=("one of: $*")
-        return 1
+        if [[ "$optional" -eq 1 ]]; then
+            _MISSING_OPTIONAL_DEPS+=("one of: ${cmds[*]}")
+            log_debug "plugin_contract" "Optional dependency missing: one of: ${cmds[*]}"
+            return 0
+        else
+            log_warn "plugin_contract" "None of the required commands found: ${cmds[*]}"
+            _MISSING_DEPS+=("one of: ${cmds[*]}")
+            return 1
+        fi
     fi
 
     return 0

--- a/src/core/bootstrap.sh
+++ b/src/core/bootstrap.sh
@@ -266,7 +266,7 @@ _setup_plugin_keybindings() {
                 local key
                 for key in "${_conflict_check_keys[@]}"; do
                     local existing_cmd
-                    existing_cmd=$(tmux list-keys -T prefix 2>/dev/null | grep -E "^bind-key[[:space:]]+-T[[:space:]]+prefix[[:space:]]+${key//[\/\\]/\\\\}" | grep -v "powerkit" | head -1 | awk '{$1=$2=$3=$4=""; print $0}' | sed 's/^ *//')
+                    existing_cmd=$(tmux list-keys -T prefix 2>/dev/null | awk -v k="$key" '$1=="bind-key" && $3=="prefix" && $4==k && !/powerkit/ { $1=$2=$3=$4=""; sub(/^[[:space:]]+/, ""); print; exit }')
 
                     if [[ -n "$existing_cmd" ]]; then
                         log_info "bootstrap" "Skipping keybindings for $plugin_name: key '$key' already bound (action=skip)"

--- a/src/core/cache.sh
+++ b/src/core/cache.sh
@@ -92,6 +92,11 @@ _cache_invalidate_memory() {
     for mem_key in "${!_MEMORY_CACHE[@]}"; do
         [[ "$mem_key" == "$mem_prefix"* ]] && unset "_MEMORY_CACHE[$mem_key]"
     done
+
+    # Invalidate file mtime cache as well
+    local safe_key="${key//[^a-zA-Z0-9_-]/_}"
+    local cache_file="${_CACHE_DIR}/${safe_key}"
+    unset '_FILE_MTIME_CACHE['"$cache_file"']'
 }
 
 # Get file modification time in seconds since epoch (cycle-cached).
@@ -268,7 +273,15 @@ cache_clear_prefix() {
 
     local file
     for file in "$_CACHE_DIR/${safe_prefix}"*; do
-        [[ -f "$file" ]] && rm -f "$file" 2>/dev/null || true
+        if [[ -f "$file" ]]; then
+            rm -f "$file" 2>/dev/null || true
+            unset '_FILE_MTIME_CACHE['"$file"']'
+        fi
+    done
+
+    local mem_key
+    for mem_key in "${!_MEMORY_CACHE[@]}"; do
+        [[ "$mem_key" == "${prefix}"* || "$mem_key" == "${safe_prefix}"* ]] && unset "_MEMORY_CACHE[$mem_key]"
     done
 }
 
@@ -278,6 +291,7 @@ cache_clear_all() {
     _ensure_cache_dir
     rm -f "$_CACHE_DIR"/* 2>/dev/null || true
     _MEMORY_CACHE=()
+    _FILE_MTIME_CACHE=()
 }
 
 # =============================================================================

--- a/src/core/color_generator.sh
+++ b/src/core/color_generator.sh
@@ -342,10 +342,11 @@ deserialize_theme_colors() {
     THEME_COLORS=()
     _COLOR_VARIANTS=()
 
-    # Stream content through awk with US as record separator.
+    # Parse content using US as delimiter in pure Bash 5.2 (no awk subprocess).
     # Each record is "key=value"; route to correct assoc based on suffix.
     local entry key value
-    while IFS= read -r entry; do
+    while IFS= read -r -d "$sep" entry || [[ -n "$entry" ]]; do
+        entry="${entry%$'\n'}"
         [[ -z "$entry" ]] && continue
         key="${entry%%=*}"
         value="${entry#*=}"
@@ -354,5 +355,5 @@ deserialize_theme_colors() {
         else
             THEME_COLORS["$key"]="$value"
         fi
-    done < <(printf "%s" "$content" | awk -v sep="$sep" 'BEGIN{RS=sep} NF')
+    done <<< "$content"
 }

--- a/src/core/defaults.sh
+++ b/src/core/defaults.sh
@@ -251,6 +251,16 @@ POWERKIT_DEFAULT_STALE_MULTIPLIER="3"
 POWERKIT_DEFAULT_STALE_COLOR_VARIANT="-darkest"
 
 # =============================================================================
+# BATTERY SAVER MODE
+# =============================================================================
+# @powerkit_battery_saver - Battery saving mode
+# Values: "off", "auto" (default), "on"
+# When active (or "auto" while discharging on battery):
+#   - Doubles plugin cache TTLs to reduce polling CPU consumption
+#   - Increases minimum tmux status-interval to 10s
+POWERKIT_DEFAULT_BATTERY_SAVER="auto"
+
+# =============================================================================
 # SEPARATOR CONFIGURATION
 # =============================================================================
 # @powerkit_separator_style - Main separator style between segments

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -27,6 +27,9 @@ declare -gA _PLUGIN_STATES=()
 # External plugin counter (for unique ID generation without subshells)
 declare -g _EXTERNAL_PLUGIN_COUNTER=0
 
+# Plugins that implement plugin_should_be_active() for pane/dynamic context checks
+declare -gA _PLUGINS_WITH_CONTEXT_CHECK=([git]=1 [terraform]=1 [docker]=1 [swap]=1)
+
 # =============================================================================
 # Visibility Helpers
 # =============================================================================
@@ -74,7 +77,19 @@ _get_plugin_icon() {
 # Must be called AFTER plugin is sourced and options declared
 # Usage: ttl=$(_get_plugin_cache_ttl)
 _get_plugin_cache_ttl() {
-    get_option "cache_ttl" 2>/dev/null || echo 30
+    local ttl
+    ttl=$(get_option "cache_ttl" 2>/dev/null || echo 30)
+
+    # Battery saver multiplier
+    local battery_saver
+    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
+    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+        # Double TTL when on battery (minimum 10s)
+        (( ttl = ttl * 2 ))
+        (( ttl < 10 )) && ttl=10
+    fi
+
+    printf '%s' "$ttl"
 }
 
 # =============================================================================
@@ -569,7 +584,11 @@ _spawn_plugin_refresh() {
         declare -F plugin_declare_options &>/dev/null && plugin_declare_options
 
         # Check dependencies
-        declare -F plugin_check_dependencies &>/dev/null && plugin_check_dependencies || exit 1
+        if declare -F plugin_check_dependencies &>/dev/null && ! plugin_check_dependencies; then
+            cache_set "plugin_${name}_data" "HIDDEN"
+            cache_set "plugin_${name}_ttl" "${_DEFAULT_CACHE_TTL_LONG:-3600}"
+            exit 0
+        fi
 
         # Collect data
         plugin_data_clear
@@ -630,8 +649,9 @@ _collect_plugin_sync() {
     # Check dependencies (calls require_macos_binary for macOS plugins)
     if declare -F plugin_check_dependencies &>/dev/null; then
         if ! plugin_check_dependencies; then
-            # Dependencies not met - return HIDDEN and cache it
+            # Dependencies not met - return HIDDEN and cache it with long TTL
             cache_set "$cache_key" "HIDDEN"
+            cache_set "$ttl_cache_key" "${_DEFAULT_CACHE_TTL_LONG:-3600}"
             printf 'HIDDEN'
             return 0
         fi
@@ -802,8 +822,8 @@ collect_plugin_render_data() {
 
     # FRESH: age <= TTL → return cache immediately
     if [[ $cache_age -ge 0 && $cache_age -le $ttl && -n "$cached_data" ]]; then
-        # Quick check: if cached data is not "HIDDEN", verify visibility conditions
-        if [[ "$cached_data" != "HIDDEN" ]]; then
+        # For plugins with dynamic context checks (e.g. git, terraform, docker, swap), verify visibility
+        if [[ "$cached_data" != "HIDDEN" && -v _PLUGINS_WITH_CONTEXT_CHECK[$name] ]]; then
             clear_options_cache "$name" 2>/dev/null || true
             # shellcheck disable=SC1090
             . "$plugin_file"
@@ -835,18 +855,20 @@ collect_plugin_render_data() {
     #
     # This ensures plugins don't constantly appear "stale" just because their cache
     # is slightly older than TTL - which would happen with TTL close to status-interval.
-    if [[ $cache_age -gt $ttl && $cache_age -le $stale_limit && -n "$cached_data" && "$cached_data" != "HIDDEN" ]]; then
-        # Source plugin for visibility check
-        clear_options_cache "$name" 2>/dev/null || true
-        # shellcheck disable=SC1090
-        . "$plugin_file"
-        declare -F plugin_declare_options &>/dev/null && plugin_declare_options
+    if [[ $cache_age -gt $ttl && $cache_age -le $stale_limit && -n "$cached_data" ]]; then
+        # For plugins with dynamic context checks, verify visibility before refresh
+        if [[ -v _PLUGINS_WITH_CONTEXT_CHECK[$name] ]]; then
+            clear_options_cache "$name" 2>/dev/null || true
+            # shellcheck disable=SC1090
+            . "$plugin_file"
+            declare -F plugin_declare_options &>/dev/null && plugin_declare_options
 
-        # Use unified visibility check
-        if ! _check_plugin_context_visibility; then
-            _spawn_plugin_refresh "$name"
-            printf 'HIDDEN'
-            return 0
+            # Use unified visibility check
+            if ! _check_plugin_context_visibility; then
+                _spawn_plugin_refresh "$name"
+                printf 'HIDDEN'
+                return 0
+            fi
         fi
 
         _spawn_plugin_refresh "$name"

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -28,7 +28,7 @@ declare -gA _PLUGIN_STATES=()
 declare -g _EXTERNAL_PLUGIN_COUNTER=0
 
 # Plugins that implement plugin_should_be_active() for pane/dynamic context checks
-declare -gA _PLUGINS_WITH_CONTEXT_CHECK=([git]=1 [terraform]=1 [docker]=1 [swap]=1)
+declare -gA _PLUGINS_WITH_CONTEXT_CHECK=([git]=1 [terraform]=1)
 
 # =============================================================================
 # Visibility Helpers
@@ -81,9 +81,7 @@ _get_plugin_cache_ttl() {
     ttl=$(get_option "cache_ttl" 2>/dev/null || echo 30)
 
     # Battery saver multiplier
-    local battery_saver
-    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
-    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+    if is_battery_saver_active; then
         # Double TTL when on battery (minimum 10s)
         (( ttl = ttl * 2 ))
         (( ttl < 10 )) && ttl=10
@@ -107,29 +105,18 @@ discover_plugins() {
         return 0
     }
 
+    local items=()
     if declare -F _parse_plugin_list &>/dev/null; then
         _parse_plugin_list "$plugins_str"
-        local plugin_name
-        for plugin_name in "${_PARSED_PLUGINS[@]}"; do
-            trim_inplace plugin_name
-            [[ -z "$plugin_name" ]] && continue
-            if [[ "$plugin_name" == external\(* ]]; then
-                _register_external_plugin "$plugin_name"
-            else
-                _register_plugin "$plugin_name"
-            fi
-        done
-        log_info "lifecycle" "Discovered ${#_PLUGINS[@]} plugins"
-        return 0
+        items=("${_PARSED_PLUGINS[@]}")
+    else
+        local IFS=','
+        items=($plugins_str)
     fi
 
-    # Parse comma-separated list, stripping group(...) wrapper if present
-    local IFS=','
     local plugin_name
-    for plugin_name in $plugins_str; do
-        # Trim whitespace (uses nameref - zero subshells)
+    for plugin_name in "${items[@]}"; do
         trim_inplace plugin_name
-
         [[ -z "$plugin_name" ]] && continue
 
         # Handle group(...) wrappers
@@ -142,8 +129,6 @@ discover_plugins() {
         trim_inplace plugin_name
         [[ -z "$plugin_name" ]] && continue
 
-        # Check if it's an external plugin
-        # External plugins have format: external("...")
         if [[ "$plugin_name" == external\(* ]]; then
             _register_external_plugin "$plugin_name"
         else

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -110,8 +110,7 @@ discover_plugins() {
         _parse_plugin_list "$plugins_str"
         items=("${_PARSED_PLUGINS[@]}")
     else
-        local IFS=','
-        items=($plugins_str)
+        IFS=',' read -r -a items <<< "$plugins_str"
     fi
 
     local plugin_name

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -107,13 +107,39 @@ discover_plugins() {
         return 0
     }
 
-    # Parse comma-separated list
+    if declare -F _parse_plugin_list &>/dev/null; then
+        _parse_plugin_list "$plugins_str"
+        local plugin_name
+        for plugin_name in "${_PARSED_PLUGINS[@]}"; do
+            trim_inplace plugin_name
+            [[ -z "$plugin_name" ]] && continue
+            if [[ "$plugin_name" == external\(* ]]; then
+                _register_external_plugin "$plugin_name"
+            else
+                _register_plugin "$plugin_name"
+            fi
+        done
+        log_info "lifecycle" "Discovered ${#_PLUGINS[@]} plugins"
+        return 0
+    fi
+
+    # Parse comma-separated list, stripping group(...) wrapper if present
     local IFS=','
     local plugin_name
     for plugin_name in $plugins_str; do
         # Trim whitespace (uses nameref - zero subshells)
         trim_inplace plugin_name
 
+        [[ -z "$plugin_name" ]] && continue
+
+        # Handle group(...) wrappers
+        if [[ "$plugin_name" == group\(* ]]; then
+            plugin_name="${plugin_name#group(}"
+        fi
+        if [[ "$plugin_name" == *\) && "$plugin_name" != external\(* ]]; then
+            plugin_name="${plugin_name%)}"
+        fi
+        trim_inplace plugin_name
         [[ -z "$plugin_name" ]] && continue
 
         # Check if it's an external plugin
@@ -607,7 +633,7 @@ _spawn_plugin_refresh() {
         # Get health
         if ! declare -F plugin_get_health &>/dev/null; then
             printf 'failed'
-            return 1
+            exit 1
         fi
         health=$(plugin_get_health)
 
@@ -616,7 +642,7 @@ _spawn_plugin_refresh() {
         # Get icon
         if ! declare -F plugin_get_icon &>/dev/null; then
             printf 'failed'
-            return 1
+            exit 1
         fi
         icon=$(plugin_get_icon)
 
@@ -842,7 +868,7 @@ collect_plugin_render_data() {
 
     # Get stale multiplier
     local stale_multiplier
-    stale_multiplier="${POWERKIT_DEFAULT_STALE_MULTIPLIER:-3}"
+    stale_multiplier=$(get_tmux_option "@powerkit_stale_multiplier" "${POWERKIT_DEFAULT_STALE_MULTIPLIER:-3}")
     local stale_limit=$((ttl * stale_multiplier))
 
     # STALE WINDOW: TTL < age <= TTL*multiplier → return cache + background refresh

--- a/src/core/options.sh
+++ b/src/core/options.sh
@@ -60,9 +60,12 @@ _batch_load_tmux_options() {
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
         # Parse: @powerkit_option "value" or @powerkit_option value
-        if [[ "$line" =~ ^(@powerkit[a-zA-Z0-9_]+)[[:space:]]+\"?([^\"]*)\"?$ ]]; then
+        if [[ "$line" =~ ^(@powerkit[a-zA-Z0-9_]+)[[:space:]]+(.*)$ ]]; then
             local key="${BASH_REMATCH[1]}"
             local value="${BASH_REMATCH[2]}"
+            if [[ "$value" =~ ^\"(.*)\"$ ]]; then
+                value="${BASH_REMATCH[1]}"
+            fi
             _TMUX_OPTIONS_CACHE["$key"]="$value"
         fi
     done <<<"$output"
@@ -82,7 +85,7 @@ _inject_default_plugin_options() {
         local name
         name="${opt%%${_OPT_DELIM}*}"
         local current_opts="${_PLUGIN_OPTIONS[$_CURRENT_PLUGIN]:-}"
-        if [[ ",${current_opts}," != *,${name}${_OPT_DELIM}* ]]; then
+        if [[ ";${current_opts};" != *";${name}${_OPT_DELIM}"* ]]; then
             if [[ -n "$current_opts" ]]; then _PLUGIN_OPTIONS["$_CURRENT_PLUGIN"]+=";"; fi
             _PLUGIN_OPTIONS["$_CURRENT_PLUGIN"]+="$opt"
         fi

--- a/src/core/theme_loader.sh
+++ b/src/core/theme_loader.sh
@@ -195,12 +195,16 @@ load_powerkit_theme() {
         variant="$_CURRENT_VARIANT"
     fi
 
-    # Tmux options override cache
-    local opt_theme opt_variant
+    local opt_theme opt_variant custom_path
     opt_theme=$(get_tmux_option "@powerkit_theme" "")
     opt_variant=$(get_tmux_option "@powerkit_theme_variant" "")
+    custom_path=$(get_tmux_option "@powerkit_custom_theme_path" "")
 
-    if [[ -n "$opt_theme" ]]; then theme="$opt_theme"; fi
+    if [[ -n "$opt_theme" ]]; then
+        theme="$opt_theme"
+    elif [[ -n "$custom_path" ]]; then
+        theme="custom"
+    fi
     if [[ -n "$opt_variant" ]]; then variant="$opt_variant"; fi
 
     # Fall back to defaults if not set

--- a/src/helpers/reload_theme.sh
+++ b/src/helpers/reload_theme.sh
@@ -3,13 +3,14 @@
 
 POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 
-# Delete all theme caches (files)
-rm -f ~/.cache/tmux-powerkit/data/theme_colors__* 2>/dev/null || true
-rm -f ~/.cache/tmux-powerkit/data/current_theme 2>/dev/null || true
-
 # Bootstrap minimal to get functions
 . "${POWERKIT_ROOT}/src/core/bootstrap.sh"
 powerkit_bootstrap_minimal
+
+# Delete all theme caches (files)
+_cache_dir="$(get_cache_dir)"
+rm -f "${_cache_dir}/theme_colors__"* 2>/dev/null || true
+rm -f "${_cache_dir}/current_theme" 2>/dev/null || true
 
 # CRITICAL: Clear in-memory global variables that cause fast-path to skip reload
 unset _CURRENT_THEME

--- a/src/plugins/audiodevices.sh
+++ b/src/plugins/audiodevices.sh
@@ -113,7 +113,7 @@ _get_audio_input() {
         local src
         src=$(pactl get-default-source 2>/dev/null)
         [[ -n "$src" ]] && pactl list sources 2>/dev/null |
-            grep -A 20 "Name: $src" | grep "Description:" |
+            grep -A 20 "Name: $src" | grep "Description:" | head -n 1 |
             cut -d: -f2- | sed 's/^ *//'
     fi
 }
@@ -125,7 +125,7 @@ _get_audio_output() {
         local sink
         sink=$(pactl get-default-sink 2>/dev/null)
         [[ -n "$sink" ]] && pactl list sinks 2>/dev/null |
-            grep -A 20 "Name: $sink" | grep "Description:" |
+            grep -A 20 "Name: $sink" | grep "Description:" | head -n 1 |
             cut -d: -f2- | sed 's/^ *//'
     fi
 }
@@ -142,9 +142,10 @@ plugin_collect() {
     local prev_mode
     prev_mode=$(cache_get "$prev_mode_key" "86400" 2>/dev/null || echo "")
     if [[ -n "$prev_mode" && "$prev_mode" != "$show" ]]; then
-        cache_clear "plugin_audiodevices"
+        cache_clear "plugin_audiodevices_data"
+        cache_clear "plugin_audiodevices_ttl"
     fi
-    cache_set "$prev_mode_key" "$show" "86400" 2>/dev/null || true
+    cache_set "$prev_mode_key" "$show" 2>/dev/null || true
 
     # Skip if audio system not available
     [[ "$show" == "off" ]] && return 0

--- a/src/plugins/battery.sh
+++ b/src/plugins/battery.sh
@@ -92,8 +92,6 @@ plugin_declare_options() {
 _has_battery() {
     if is_wsl; then
         [[ -n "$(find /sys/class/power_supply/*/capacity 2>/dev/null | head -1)" ]]
-    elif is_macos && has_cmd pmset; then
-        pmset -g batt 2>/dev/null | grep -q "InternalBattery"
     elif has_cmd acpi; then
         acpi -b 2>/dev/null | grep -q "Battery"
     elif has_cmd upower; then
@@ -118,8 +116,6 @@ _get_percentage() {
         local f
         f=$(find /sys/class/power_supply/*/capacity 2>/dev/null | head -1)
         [[ -n "$f" ]] && percent=$(cat "$f" 2>/dev/null)
-    elif is_macos && has_cmd pmset; then
-        percent=$(pmset -g batt 2>/dev/null | awk '/[0-9]+%/ {gsub(/[%;]/, "", $3); print $3; exit}')
     elif has_cmd acpi; then
         percent=$(acpi -b 2>/dev/null | awk -F'[,%]' '/Battery/ {gsub(/ /, "", $2); print $2; exit}')
     elif has_cmd upower; then
@@ -154,20 +150,6 @@ _get_charging_status() {
         if [[ -n "$f" ]]; then
             status=$(cat "$f" 2>/dev/null)
             status="${status,,}"
-        fi
-    elif is_macos && has_cmd pmset; then
-        local out
-        out=$(pmset -g batt 2>/dev/null)
-        if echo "$out" | grep -q "AC Power"; then
-            if echo "$out" | grep -qE "charging|finishing charge"; then
-                status="charging"
-            elif echo "$out" | grep -q "charged"; then
-                status="charged"
-            else
-                status="ac_power"
-            fi
-        else
-            status="discharging"
         fi
     elif has_cmd acpi; then
         if acpi -b 2>/dev/null | grep -qiE "^Battery.*: Charging"; then
@@ -224,15 +206,7 @@ _get_charging_status() {
 _get_time_remaining() {
     local time=""
 
-    if is_macos && has_cmd pmset; then
-        local out
-        out=$(pmset -g batt 2>/dev/null)
-        if echo "$out" | grep -q "(no estimate)"; then
-            time="..."
-        else
-            time=$(echo "$out" | grep -oE '[0-9]+:[0-9]+' | head -1)
-        fi
-    elif has_cmd acpi; then
+    if has_cmd acpi; then
         time=$(acpi -b 2>/dev/null | grep -oE '[0-9]+:[0-9]+:[0-9]+' | head -1 | cut -d: -f1-2)
     elif has_cmd upower; then
         local bat sec unit

--- a/src/plugins/battery.sh
+++ b/src/plugins/battery.sh
@@ -256,15 +256,55 @@ _get_time_remaining() {
 # =============================================================================
 
 plugin_collect() {
-    # Check if battery exists
-    if ! _has_battery; then
-        plugin_data_set "available" "0"
-        return
-    fi
+    local percent="0" status="unknown" time_remaining=""
 
-    local percent status
-    percent=$(_get_percentage)
-    status=$(_get_charging_status)
+    if is_macos && has_cmd pmset; then
+        local out
+        out=$(pmset -g batt 2>/dev/null)
+        if [[ "$out" != *"InternalBattery"* ]]; then
+            plugin_data_set "available" "0"
+            return 0
+        fi
+
+        # Percentage
+        if [[ "$out" =~ ([0-9]+)% ]]; then
+            percent="${BASH_REMATCH[1]}"
+        fi
+
+        # Status
+        if [[ "$out" == *"AC Power"* ]]; then
+            if [[ "$out" =~ (charging|finishing\ charge) ]]; then
+                status="charging"
+            elif [[ "$out" == *"charged"* ]]; then
+                status="charged"
+            else
+                status="ac_power"
+            fi
+        else
+            status="discharging"
+        fi
+
+        # Time remaining
+        if [[ "$out" =~ ([0-9]+:[0-9]+) ]]; then
+            time_remaining="${BASH_REMATCH[1]}"
+        elif [[ "$out" == *"(no estimate)"* ]]; then
+            time_remaining="..."
+        fi
+    else
+        # Check if battery exists
+        if ! _has_battery; then
+            plugin_data_set "available" "0"
+            return 0
+        fi
+
+        percent=$(_get_percentage)
+        status=$(_get_charging_status)
+
+        # Collect time remaining for discharging state
+        if [[ "$status" == "discharging" ]]; then
+            time_remaining=$(_get_time_remaining)
+        fi
+    fi
 
     plugin_data_set "available" "1"
     plugin_data_set "percent" "$percent"
@@ -280,11 +320,6 @@ plugin_collect() {
             ;;
     esac
 
-    # Collect time remaining for discharging state
-    local time_remaining=""
-    if [[ "$status" == "discharging" ]]; then
-        time_remaining=$(_get_time_remaining)
-    fi
     plugin_data_set "time_remaining" "${time_remaining:-}"
 }
 

--- a/src/plugins/battery.sh
+++ b/src/plugins/battery.sh
@@ -212,7 +212,8 @@ _get_charging_status() {
 
     # Normalize status
     case "$status" in
-        charging|"not charging") echo "charging" ;;
+        charging) echo "charging" ;;
+        "not charging") echo "ac_power" ;;
         full|charged) echo "charged" ;;
         discharging) echo "discharging" ;;
         *) echo "unknown" ;;
@@ -425,7 +426,7 @@ plugin_get_icon() {
     warn_th=$(get_option "warning_threshold")
     plugin_get_icon_by_range "${percent:-100}" \
         "${crit_th:-15}:icon_critical" \
-        "${warn_th:-30}:icon_low" \
+        "${warn_th:-30}:icon_warning" \
         "icon"
 }
 

--- a/src/plugins/bitbucket.sh
+++ b/src/plugins/bitbucket.sh
@@ -218,7 +218,8 @@ _count_issues() {
 
     # Cloud API
     url="${bitbucket_url}/repositories/$workspace/$repo_slug/issues?q=state=%22new%22+OR+state=%22open%22&pagelen=0"
-    response=$(_bb_api_call "$url")
+    response=$(_bb_api_call "$url") || return 1
+    [[ -z "$response" ]] && return 1
     json_get_size "$response"
 }
 
@@ -234,7 +235,8 @@ _count_prs() {
         url="${bitbucket_url}/repositories/$workspace/$repo_slug/pullrequests?state=OPEN&pagelen=0"
     fi
 
-    response=$(_bb_api_call "$url")
+    response=$(_bb_api_call "$url") || return 1
+    [[ -z "$response" ]] && return 1
     json_get_size "$response"
 }
 

--- a/src/plugins/bitwarden.sh
+++ b/src/plugins/bitwarden.sh
@@ -108,7 +108,7 @@ plugin_get_icon() {
 # Load BW_SESSION from tmux environment
 _load_bw_session() {
     local session output
-    output=$(tmux show-environment BW_SESSION 2>/dev/null) || true
+    output=$(tmux show-environment BW_SESSION 2>/dev/null || tmux show-environment -g BW_SESSION 2>/dev/null) || true
     if [[ -n "$output" && "$output" != "-BW_SESSION" ]]; then
         session="${output#BW_SESSION=}"
         [[ -n "$session" ]] && export BW_SESSION="$session"
@@ -174,7 +174,7 @@ plugin_collect() {
     has_cmd bw || has_cmd rbw || return 0
 
     local status
-    status=$(_get_vault_status) || return 0
+    status=$(_get_vault_status) || return 1
 
     if [[ "$status" == "unlocked" ]]; then
         plugin_data_set "unlocked" "1"

--- a/src/plugins/bluetooth.sh
+++ b/src/plugins/bluetooth.sh
@@ -88,10 +88,7 @@ _get_bt_macos_blueutil() {
     # Check power state
     [[ "$(blueutil -p 2>/dev/null)" == "0" ]] && { echo "off:"; return 0; }
 
-    local devices="" line name mac bat sp_info battery_info
-
-    # Get system_profiler info for battery details (AirPods, etc.)
-    sp_info=$(system_profiler SPBluetoothDataType 2>/dev/null)
+    local devices="" line name mac bat sp_info="" battery_info
 
     while IFS= read -r line; do
         name="" mac="" bat=""
@@ -104,10 +101,14 @@ _get_bt_macos_blueutil() {
         # Try blueutil for battery first
         bat=$(blueutil --info "$mac" 2>/dev/null | grep -i battery | grep -oE '[0-9]+' | head -1)
 
-        # Fallback: system_profiler for devices like AirPods
+        # Fallback: system_profiler for devices like AirPods (lazy fetch)
         battery_info=""
-        if [[ -z "$bat" && -n "$sp_info" ]]; then
-            battery_info=$(echo "$sp_info" | awk -v device="$name" '
+        if [[ -z "$bat" ]]; then
+            if [[ -z "$sp_info" ]]; then
+                sp_info=$(system_profiler SPBluetoothDataType 2>/dev/null)
+            fi
+            if [[ -n "$sp_info" ]]; then
+                battery_info=$(echo "$sp_info" | awk -v device="$name" '
                 # Start capturing when we find our device
                 $0 ~ device ":" { in_device=1; next }
                 # Stop when we hit another device or Not Connected section
@@ -130,6 +131,7 @@ _get_bt_macos_blueutil() {
                 }
                 END { print batteries }
             ')
+            fi
         fi
 
         [[ -n "$devices" ]] && devices+="|"

--- a/src/plugins/brightness.sh
+++ b/src/plugins/brightness.sh
@@ -90,11 +90,12 @@ plugin_get_health() { printf 'ok'; }
 
 plugin_get_context() {
     local level=$(plugin_data_get "level")
-    level="${level:-50}"
+    local num_level="${level%%[^0-9]*}"
+    num_level="${num_level:-50}"
 
-    if (( level <= 30 )); then
+    if (( num_level <= 30 )); then
         printf 'low'
-    elif (( level <= 70 )); then
+    elif (( num_level <= 70 )); then
         printf 'medium'
     else
         printf 'high'
@@ -103,11 +104,12 @@ plugin_get_context() {
 
 plugin_get_icon() {
     local level=$(plugin_data_get "level")
-    level="${level:-50}"
+    local num_level="${level%%[^0-9]*}"
+    num_level="${num_level:-50}"
 
-    if (( level <= 30 )); then
+    if (( num_level <= 30 )); then
         get_option "icon_low"
-    elif (( level <= 70 )); then
+    elif (( num_level <= 70 )); then
         get_option "icon_medium"
     else
         get_option "icon"
@@ -275,7 +277,11 @@ plugin_collect() {
         level=$(_get_brightness_linux)
     fi
 
-    [[ -n "$level" ]] && plugin_data_set "level" "$level"
+    if [[ -n "$level" ]]; then
+        plugin_data_set "level" "$level"
+    else
+        return 1
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/camera.sh
+++ b/src/plugins/camera.sh
@@ -95,7 +95,11 @@ _detect_linux() {
 }
 
 _is_camera_active() {
-    is_macos && _detect_macos || _detect_linux
+    if is_macos; then
+        _detect_macos
+    else
+        _detect_linux
+    fi
 }
 
 # =============================================================================

--- a/src/plugins/chezmoi.sh
+++ b/src/plugins/chezmoi.sh
@@ -139,8 +139,6 @@ plugin_collect() {
     source_path=$(chezmoi source-path 2>/dev/null) || return 0
     [[ -n "$source_path" && -d "$source_path" ]] || return 0
 
-    plugin_data_set "available" "1"
-
     exclude_types=$(get_option "exclude_types")
 
     # Use chezmoi status in a non-interactive safe mode.
@@ -148,6 +146,8 @@ plugin_collect() {
     # manager prompts, while still detecting real source/target differences for
     # the remaining entry types.
     status_output=$(chezmoi status --no-pager --no-tty --exclude "$exclude_types" 2>/dev/null) || return 1
+
+    plugin_data_set "available" "1"
 
     if [[ -z "$status_output" ]]; then
         count=0

--- a/src/plugins/cloud.sh
+++ b/src/plugins/cloud.sh
@@ -118,6 +118,18 @@ plugin_get_icon() {
     esac
 }
 
+_cloud_timeout() {
+    local duration="$1"
+    shift
+    if has_cmd timeout; then
+        timeout "$duration" "$@"
+    elif has_cmd gtimeout; then
+        gtimeout "$duration" "$@"
+    else
+        "$@"
+    fi
+}
+
 # =============================================================================
 # AWS Detection
 # =============================================================================
@@ -140,7 +152,9 @@ _is_aws_session_active() {
             [[ -z "$has_token" ]] && continue
             expires_at=$(jq -r '.expiresAt // empty' "$cache_file" 2>/dev/null)
             [[ -z "$expires_at" ]] && continue
-            expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expires_at" +%s 2>/dev/null ||
+            local exp_clean="${expires_at%%.*}"
+            [[ "$expires_at" == *Z* ]] && exp_clean="${exp_clean}Z"
+            expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$exp_clean" +%s 2>/dev/null ||
                 date -d "$expires_at" +%s 2>/dev/null)
             [[ -n "$expires_epoch" && "$expires_epoch" -gt "$now" ]] && return 0
         done
@@ -155,14 +169,16 @@ _is_aws_session_active() {
             [[ -f "$cache_file" ]] || continue
             expiration=$(jq -r '.Credentials.Expiration // empty' "$cache_file" 2>/dev/null)
             [[ -z "$expiration" ]] && continue
-            expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$expiration" +%s 2>/dev/null ||
+            local exp_clean="${expiration%%.*}"
+            [[ "$expiration" == *Z* ]] && exp_clean="${exp_clean}Z"
+            expires_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$exp_clean" +%s 2>/dev/null ||
                 date -d "$expiration" +%s 2>/dev/null)
             [[ -n "$expires_epoch" && "$expires_epoch" -gt "$now" ]] && return 0
         done
     fi
 
     # Method 3: Quick STS check (fallback)
-    has_cmd aws && timeout 2 aws sts get-caller-identity --profile "$profile" &>/dev/null && return 0
+    has_cmd aws && _cloud_timeout 2 aws sts get-caller-identity --profile "$profile" &>/dev/null && return 0
 
     return 1
 }
@@ -230,7 +246,7 @@ _get_aws_context() {
 
     [[ -n "$region" && "$show_region" == "true" ]] && context="${profile}@${region}" || context="$profile"
     if [[ "$logged_in" == "true" && "$show_account" == "true" ]]; then
-        account=$(timeout 2 aws sts get-caller-identity --profile "$profile" --query Account --output text 2>/dev/null)
+        account=$(_cloud_timeout 2 aws sts get-caller-identity --profile "$profile" --query Account --output text 2>/dev/null)
         [[ "$account" =~ ^[0-9]{12}$ ]] && context+="@${account}"
     fi
 
@@ -264,7 +280,7 @@ _is_gcp_session_active() {
     [[ -f "$cfg" ]] && grep -q "^account" "$cfg" 2>/dev/null && return 0
 
     # Fallback: Quick gcloud check
-    has_cmd gcloud && timeout 2 gcloud auth print-access-token &>/dev/null && return 0
+    has_cmd gcloud && _cloud_timeout 2 gcloud auth print-access-token &>/dev/null && return 0
 
     return 1
 }
@@ -317,7 +333,8 @@ _is_azure_session_active() {
         local now=$EPOCHSECONDS expires expires_epoch
         expires=$(jq -r '.[0].expiresOn // empty' "$tokens" 2>/dev/null)
         if [[ -n "$expires" ]]; then
-            expires_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$expires" +%s 2>/dev/null ||
+            local exp_clean="${expires%%.*}"
+            expires_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$exp_clean" +%s 2>/dev/null ||
                 date -d "$expires" +%s 2>/dev/null)
             [[ -n "$expires_epoch" && "$expires_epoch" -gt "$now" ]] && return 0
         fi
@@ -328,7 +345,7 @@ _is_azure_session_active() {
     [[ -f "$msal_cache" ]] && has_cmd jq && jq -e '.AccessToken | length > 0' "$msal_cache" &>/dev/null && return 0
 
     # Fallback: Quick az check
-    has_cmd az && timeout 2 az account show &>/dev/null && return 0
+    has_cmd az && _cloud_timeout 2 az account show &>/dev/null && return 0
 
     return 1
 }
@@ -427,7 +444,13 @@ _get_cloud_context() {
 
 plugin_collect() {
     local result provider context logged_in
-    result=$(_get_cloud_context) || return 0
+    if ! result=$(_get_cloud_context); then
+        plugin_data_set "provider" ""
+        plugin_data_set "context" ""
+        plugin_data_set "logged_in" "false"
+        plugin_data_set "credential_status" ""
+        return 0
+    fi
 
     # Parse "provider:context:logged_in"
     provider="${result%%:*}"

--- a/src/plugins/connectivity.sh
+++ b/src/plugins/connectivity.sh
@@ -23,8 +23,7 @@ plugin_get_metadata() {
 # =============================================================================
 
 plugin_check_dependencies() {
-    # network.sh is already sourced via plugin_contract.sh
-    has_cmd "curl" || return 1
+    require_cmd "curl" || return 1
     return 0
 }
 

--- a/src/plugins/cpu.sh
+++ b/src/plugins/cpu.sh
@@ -192,9 +192,9 @@ _get_cpu_macos_top() {
 
     if [[ "$top_line" =~ ([0-9.]+)%\ user,?[[:space:]]*([0-9.]+)%\ sys,?[[:space:]]*([0-9.]+)%\ idle ]]; then
         idle="${BASH_REMATCH[3]}"
-        # Use awk instead of bc (more portable, no external dependency)
-        busy=$(awk -v i="$idle" 'BEGIN {printf "%.0f", 100 - i}')
-        printf '%.0f' "${busy:-0}"
+        local idle_int="${idle%.*}"
+        busy=$(( 100 - ${idle_int:-0} ))
+        printf '%d' "${busy:-0}"
         return 0
     fi
 

--- a/src/plugins/crypto.sh
+++ b/src/plugins/crypto.sh
@@ -120,13 +120,11 @@ _format_price() {
 
     if [[ "$format" == "short" ]]; then
         # Convert to K, M notation
-        if [[ $(echo "$price >= 1000000" | bc -l 2>/dev/null || echo 0) -eq 1 ]]; then
-            awk -v p="$price" 'BEGIN { printf "%.1fM", p/1000000 }'
-        elif [[ $(echo "$price >= 1000" | bc -l 2>/dev/null || echo 0) -eq 1 ]]; then
-            awk -v p="$price" 'BEGIN { printf "%.1fk", p/1000 }'
-        else
-            awk -v p="$price" 'BEGIN { printf "%.0f", p }'
-        fi
+        awk -v p="$price" 'BEGIN {
+            if (p >= 1000000) printf "%.1fM", p/1000000
+            else if (p >= 1000) printf "%.1fk", p/1000
+            else printf "%.0f", p
+        }'
     else
         # Full format with commas
         printf "%'.2f" "$price" 2>/dev/null || printf "%.2f" "$price"

--- a/src/plugins/disk.sh
+++ b/src/plugins/disk.sh
@@ -124,7 +124,7 @@ _get_disk_percent() {
     local real_mount
     real_mount=$(_resolve_mount "$mount")
 
-    /bin/df -Pk "$real_mount" 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }'
+    df -Pk "$real_mount" 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }'
 }
 
 # Get inode percentage used. Falls back to the platform's non-POSIX form.
@@ -132,7 +132,7 @@ _get_inode_percent() {
     local mount="$1"
     local real_mount output
     real_mount=$(_resolve_mount "$mount")
-    output=$(/bin/df -Pi "$real_mount" 2>/dev/null || /bin/df -i "$real_mount" 2>/dev/null)
+    output=$(df -Pi "$real_mount" 2>/dev/null || df -i "$real_mount" 2>/dev/null)
     awk 'NR==2 { gsub(/%/, "", $5); print $5 }' <<<"$output"
 }
 
@@ -148,7 +148,7 @@ _get_disk_info() {
     local GB=$((1024 * 1024 * 1024))
     local TB=$((1024 * 1024 * 1024 * 1024))
 
-    /bin/df -Pk "$real_mount" 2>/dev/null | awk -v fmt="$format" \
+    df -Pk "$real_mount" 2>/dev/null | awk -v fmt="$format" \
         -v KB="$KB" -v MB="$MB" -v GB="$GB" -v TB="$TB" '
         NR==2 {
             gsub(/%/, "", $5)
@@ -280,7 +280,7 @@ plugin_get_health() {
     fi
 
     # Higher is worse (default behavior)
-    evaluate_threshold_health "${max_pct:-0}" "${warn_th:-70}" "${crit_th:-90}"
+    evaluate_threshold_health "${max_pct:-0}" "${warn_th:-80}" "${crit_th:-90}"
 }
 
 # =============================================================================

--- a/src/plugins/docker.sh
+++ b/src/plugins/docker.sh
@@ -51,11 +51,13 @@ _container_timeout() {
 }
 
 plugin_check_dependencies() {
-    [[ -n "$(_container_runtime)" ]]
-}
-
-plugin_should_be_active() {
-    [[ -n "$(_container_runtime)" ]]
+    local configured
+    configured=$(get_option "runtime")
+    case "$configured" in
+    docker) require_cmd "docker" || return 1 ;;
+    podman) require_cmd "podman" || return 1 ;;
+    *)      require_any_cmd "docker" "podman" || return 1 ;;
+    esac
 }
 
 plugin_get_content_type() { printf 'dynamic'; }

--- a/src/plugins/fan.sh
+++ b/src/plugins/fan.sh
@@ -62,7 +62,7 @@ plugin_check_dependencies() {
 plugin_declare_options() {
     # Display options
     declare_option "source" "string" "auto" "Fan source (auto|dell|thinkpad|hwmon)"
-    declare_option "format" "string" "icon_k" "Display format (rpm|krpm|number|icon|icon_k)"
+    declare_option "format" "string" "krpm" "Display format (rpm|krpm|number)"
     declare_option "selection" "string" "active" "Fan selection: active (RPM>0) or all (include idle)"
     declare_option "separator" "string" " | " "Separator between multiple fans"
 
@@ -328,19 +328,15 @@ _get_fan_speed() {
 
 _format_rpm() {
     local rpm="$1"
-    local format icon
+    local format
     format=$(get_option "format")
 
     case "$format" in
     number) printf '%s' "$rpm" ;;
-    krpm) awk "BEGIN {printf \"%.1fk\", $rpm / 1000}" ;;
-    icon)
-        icon=$(get_option "icon")
-        printf '%s %s' "$icon" "$rpm"
-        ;;
-    icon_k)
-        icon=$(get_option "icon")
-        awk -v icon="$icon" "BEGIN {printf \"%s %.1fk\", icon, $rpm / 1000}"
+    krpm|icon_k)
+        local k=$((rpm / 1000))
+        local d=$(((rpm % 1000) / 100))
+        printf '%d.%dk' "$k" "$d"
         ;;
     *) printf '%s' "$rpm" ;;
     esac

--- a/src/plugins/git.sh
+++ b/src/plugins/git.sh
@@ -147,10 +147,15 @@ plugin_collect() {
             # Clean branch name
             branch="${branch%%...*}"
             branch="${branch%% \[*}"
-            if [[ "$branch" == "HEAD (detached "* ]]; then
+            if [[ "$branch" == "No commits yet on "* ]]; then
+                branch="${branch#No commits yet on }"
+            elif [[ "$branch" == "HEAD (detached "* ]]; then
                 detached=1
                 branch="${branch#HEAD (detached }"
                 branch="${branch%)}"
+            elif [[ "$branch" == "HEAD (no branch)" ]]; then
+                detached=1
+                branch="HEAD"
             fi
         elif [[ -n "$line" ]]; then
             # File change line

--- a/src/plugins/github.sh
+++ b/src/plugins/github.sh
@@ -289,19 +289,19 @@ _fetch_via_gh_cli() {
     if ! gh repo set-default --view &>/dev/null; then
         # Use gh search for user's issues/PRs across all repos
         if [[ "$show_issues" == "true" ]]; then
-            issues=$(gh search issues --assignee "@me" --state open --json number 2>/dev/null | grep -c '"number"' || echo "0")
+            issues=$(gh search issues --assignee "@me" --state open --json number 2>/dev/null | grep -c '"number"' || true)
         fi
 
         if [[ "$show_prs" == "true" ]]; then
-            prs=$(gh search prs --author "@me" --state open --json number 2>/dev/null | grep -c '"number"' || echo "0")
+            prs=$(gh search prs --author "@me" --state open --json number 2>/dev/null | grep -c '"number"' || true)
         fi
     else
         if [[ "$show_issues" == "true" ]]; then
-            issues=$(gh issue list --assignee "@me" --state open --json number 2>/dev/null | grep -c '"number"' || echo "0")
+            issues=$(gh issue list --assignee "@me" --state open --json number 2>/dev/null | grep -c '"number"' || true)
         fi
 
         if [[ "$show_prs" == "true" ]]; then
-            prs=$(gh pr list --author "@me" --state open --json number 2>/dev/null | grep -c '"number"' || echo "0")
+            prs=$(gh pr list --author "@me" --state open --json number 2>/dev/null | grep -c '"number"' || true)
         fi
     fi
 

--- a/src/plugins/gitlab.sh
+++ b/src/plugins/gitlab.sh
@@ -216,7 +216,7 @@ _make_gitlab_head_call() {
     printf -v token '%s' "$(_get_token)"
     # Same credential-safe transport for HEAD requests. The header is
     # forwarded via stdin; only the URL is in argv.
-    printf 'header = "PRIVATE-TOKEN: %s"\nheader = "X-Head-Only: 1"\nrequest = "HEAD"\n' "$token" |
+    printf 'header = "PRIVATE-TOKEN: %s"\nhead = true\n' "$token" |
         curl -sf --config - --connect-timeout 5 --max-time 10 "$url" 2>/dev/null
 }
 
@@ -235,7 +235,7 @@ _count_issues() {
         count=$(echo "$response" | grep -o '"opened":[0-9]*' | grep -o '[0-9]*' | head -1)
     fi
 
-    [[ -z "$count" || "$count" == "null" ]] && return 1
+    [[ -z "$count" ]] && return 1
     echo "$count"
 }
 
@@ -259,11 +259,11 @@ _fetch_via_glab_cli() {
     local issues=0 mrs=0
 
     if [[ "$show_mrs" == "true" ]]; then
-        mrs=$(glab mr list --assignee @me --state opened 2>/dev/null | wc -l | tr -d ' ')
+        mrs=$(glab mr list --assignee @me --state opened 2>/dev/null | grep -c '^[!#]' || true)
     fi
 
     if [[ "$show_issues" == "true" ]]; then
-        issues=$(glab issue list --assignee @me --state opened 2>/dev/null | wc -l | tr -d ' ')
+        issues=$(glab issue list --assignee @me --state opened 2>/dev/null | grep -c '^#' || true)
     fi
 
     echo "$issues $mrs"

--- a/src/plugins/gpu.sh
+++ b/src/plugins/gpu.sh
@@ -128,7 +128,7 @@ plugin_get_health() {
     mem_warn="${mem_warn:-70}"
     mem_crit="${mem_crit:-90}"
 
-    if [[ "${mem_total:-0}" -gt 0 ]]; then
+    if [[ "${mem_total:-0}" =~ ^[0-9]+$ && "${mem_total:-0}" -gt 0 && "${mem_used:-0}" =~ ^[0-9]+$ ]]; then
         mem_percent=$(((mem_used * 100) / mem_total))
         if ((mem_percent >= mem_crit)); then
             health="error"
@@ -142,7 +142,7 @@ plugin_get_health() {
     temp=$(plugin_data_get "temp")
     temp_warn=$(get_option "temp_warning_threshold")
     temp_crit=$(get_option "temp_critical_threshold")
-    temp="${temp:-0}"
+    [[ "$temp" =~ ^[0-9]+$ ]] || temp=0
     temp_warn="${temp_warn:-70}"
     temp_crit="${temp_crit:-85}"
 
@@ -259,8 +259,15 @@ plugin_collect() {
                 --format=csv,noheader,nounits 2>/dev/null | head -1)
             if [[ -n "$nvidia_csv" ]]; then
                 IFS=',' read -r usage temp mem_used mem_total _ <<<"$nvidia_csv"
-                mem_used_mb="${mem_used:-0}"
-                mem_total_mb="${mem_total:-0}"
+                usage=$(trim "$usage")
+                temp=$(trim "$temp")
+                mem_used=$(trim "$mem_used")
+                mem_total=$(trim "$mem_total")
+                [[ "$temp" =~ ^[0-9]+$ ]] || temp=""
+                [[ "$mem_used" =~ ^[0-9]+$ ]] || mem_used="0"
+                [[ "$mem_total" =~ ^[0-9]+$ ]] || mem_total="0"
+                mem_used_mb="$mem_used"
+                mem_total_mb="$mem_total"
 
                 [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && {
                     available=1
@@ -283,7 +290,7 @@ plugin_collect() {
                 if [[ -n "$hwmon_dir" && -f "${hwmon_dir}/temp1_input" ]]; then
                     local temp_milli
                     temp_milli=$(cat "${hwmon_dir}/temp1_input" 2>/dev/null)
-                    temp=$((temp_milli / 1000))
+                    [[ "$temp_milli" =~ ^[0-9]+$ ]] && temp=$((temp_milli / 1000))
                 fi
 
                 # AMD VRAM via drm (if available)
@@ -292,8 +299,10 @@ plugin_collect() {
                     vram_used=$(cat "${amd_gpu_dir}/mem_info_vram_used" 2>/dev/null)
                     vram_total=$(cat "${amd_gpu_dir}/mem_info_vram_total" 2>/dev/null)
                     # Convert bytes to MB
-                    mem_used_mb=$((vram_used / 1048576))
-                    mem_total_mb=$((vram_total / 1048576))
+                    if [[ "$vram_used" =~ ^[0-9]+$ && "$vram_total" =~ ^[0-9]+$ ]]; then
+                        mem_used_mb=$((vram_used / 1048576))
+                        mem_total_mb=$((vram_total / 1048576))
+                    fi
                 fi
 
                 [[ -n "$usage" && "$usage" =~ ^[0-9]+$ ]] && {

--- a/src/plugins/iops.sh
+++ b/src/plugins/iops.sh
@@ -26,7 +26,7 @@ plugin_check_dependencies() {
     if is_macos; then
         require_cmd "ioreg" || return 1
     else
-        require_cmd "iostat" || return 1
+        [[ -r /proc/diskstats ]] || return 1
     fi
     return 0
 }
@@ -187,15 +187,16 @@ _get_throughput_linux() {
     local total_write_sectors=0
 
     while IFS= read -r line; do
-        local name read_sectors write_sectors
-        name=$(echo "$line" | awk '{print $3}')
+        local fields
+        read -ra fields <<<"$line"
+        local name="${fields[2]:-}"
 
         # Only count main disks, not partitions (sda not sda1, nvme0n1 not nvme0n1p1)
-        if [[ "$name" =~ ^(sd[a-z]|nvme[0-9]+n[0-9]+|vd[a-z])$ ]]; then
-            read_sectors=$(echo "$line" | awk '{print $6}')
-            write_sectors=$(echo "$line" | awk '{print $10}')
-            total_read_sectors=$((total_read_sectors + ${read_sectors:-0}))
-            total_write_sectors=$((total_write_sectors + ${write_sectors:-0}))
+        if [[ "$name" =~ ^(sd[a-z]+|nvme[0-9]+n[0-9]+|vd[a-z]+|xvd[a-z]+|mmcblk[0-9]+)$ ]]; then
+            local read_sectors="${fields[5]:-0}"
+            local write_sectors="${fields[9]:-0}"
+            total_read_sectors=$((total_read_sectors + read_sectors))
+            total_write_sectors=$((total_write_sectors + write_sectors))
         fi
     done <<<"$stats"
 

--- a/src/plugins/jira.sh
+++ b/src/plugins/jira.sh
@@ -208,10 +208,16 @@ _fetch_jira_breakdown() {
     jira_creds=$(mktemp "${TMPDIR:-/tmp}/powerkit-jira.XXXXXX") || return 1
     chmod 600 "$jira_creds"
     printf -- '-u %s:%s\n' "$email" "$token" >"$jira_creds"
-    trap 'rm -f "$jira_creds"' RETURN
+    trap 'rm -f "${jira_creds:-}" 2>/dev/null; trap - RETURN' RETURN
 
     # Paginate through results
+    local in_progress=0 todo=0 flagged=0
+    local next_token=""
+    local page_count=0
+    local max_pages=10
+
     while true; do
+        ((page_count++ > max_pages)) && break
         # Build curl args; the credential pair is in $jira_creds (not argv)
         local curl_args=(
             -sf --connect-timeout 10 --max-time 20
@@ -237,8 +243,8 @@ _fetch_jira_breakdown() {
             return 1
         fi
 
-        # Check for Jira's structured error field
-        if echo "$response" | jq -e '.errorMessages' &>/dev/null; then
+        # Check for Jira's structured error field (must be non-empty)
+        if echo "$response" | jq -e '(.errorMessages // []) | length > 0' &>/dev/null; then
             return 1
         fi
 

--- a/src/plugins/kubernetes.sh
+++ b/src/plugins/kubernetes.sh
@@ -144,7 +144,20 @@ plugin_get_icon() { get_option "icon"; }
 # =============================================================================
 
 _get_kubeconfig_path() {
-    printf '%s' "${KUBECONFIG:-$HOME/.kube/config}"
+    local kcfg="${KUBECONFIG:-$HOME/.kube/config}"
+    if [[ "$kcfg" == *":"* ]]; then
+        local p
+        local IFS=':'
+        for p in $kcfg; do
+            if [[ -f "$p" ]]; then
+                printf '%s' "$p"
+                return 0
+            fi
+        done
+        printf '%s' "${kcfg%%:*}"
+        return 0
+    fi
+    printf '%s' "$kcfg"
 }
 
 # Get kubeconfig modification time for change detection
@@ -169,7 +182,7 @@ _kubeconfig_changed() {
         if [[ "$current_mtime" != "$cached_mtime" ]]; then
             # Changed - update cache and invalidate connectivity
             cache_set "kubernetes_kubeconfig_mtime" "$current_mtime"
-            cache_invalidate "kubernetes_connectivity"
+            cache_clear "kubernetes_connectivity"
             return 0
         fi
         return 1

--- a/src/plugins/loadavg.sh
+++ b/src/plugins/loadavg.sh
@@ -85,9 +85,10 @@ plugin_get_health() {
     warning_mult="${warning_mult:-2}"
     critical_mult="${critical_mult:-4}"
 
-    # Calculate thresholds (multiplied by cores)
-    local warn_th=$((num_cores * warning_mult))
-    local crit_th=$((num_cores * critical_mult))
+    # Calculate thresholds (multiplied by cores, supporting float multipliers)
+    local warn_th crit_th
+    warn_th=$(awk -v c="$num_cores" -v m="$warning_mult" 'BEGIN { printf "%.2f", c * m }')
+    crit_th=$(awk -v c="$num_cores" -v m="$critical_mult" 'BEGIN { printf "%.2f", c * m }')
 
     # Higher is worse - use float version for load average
     evaluate_threshold_health_float "${load:-0}" "$warn_th" "$crit_th"
@@ -133,63 +134,34 @@ _format_loadavg() {
     esac
 }
 
-_get_loadavg_linux() {
-    local one five fifteen
-    
-    if [[ -r /proc/loadavg ]]; then
+_get_raw_loadavg() {
+    local one="" five="" fifteen=""
+    if is_macos; then
+        local sysctl_out
+        sysctl_out=$(sysctl -n vm.loadavg 2>/dev/null)
+        if [[ -n "$sysctl_out" ]]; then
+            read -r _ one five fifteen _ <<< "$sysctl_out"
+        else
+            local uptime_out
+            uptime_out=$(uptime 2>/dev/null)
+            if [[ "$uptime_out" =~ load\ averages?:\ ([0-9]+\.[0-9]+)\ ([0-9]+\.[0-9]+)\ ([0-9]+\.[0-9]+) ]]; then
+                one="${BASH_REMATCH[1]}"
+                five="${BASH_REMATCH[2]}"
+                fifteen="${BASH_REMATCH[3]}"
+            fi
+        fi
+    elif [[ -r /proc/loadavg ]]; then
         read -r one five fifteen _ < /proc/loadavg
     else
-        # Fallback: parse uptime output using bash regex (avoids forks)
         local uptime_out
         uptime_out=$(uptime 2>/dev/null)
-        # Extract load averages from "load average: 1.23, 4.56, 7.89"
         if [[ "$uptime_out" =~ load\ average:\ ([0-9]+\.[0-9]+),\ ([0-9]+\.[0-9]+),\ ([0-9]+\.[0-9]+) ]]; then
             one="${BASH_REMATCH[1]}"
             five="${BASH_REMATCH[2]}"
             fifteen="${BASH_REMATCH[3]}"
         fi
     fi
-    
-    _format_loadavg "$one" "$five" "$fifteen"
-}
-
-_get_loadavg_macos() {
-    local sysctl_out one five fifteen
-    sysctl_out=$(sysctl -n vm.loadavg 2>/dev/null)
-
-    if [[ -n "$sysctl_out" ]]; then
-        # Output format: "{ 1.23 4.56 7.89 }" - use bash to parse
-        read -r _ one five fifteen _ <<< "$sysctl_out"
-    else
-        # Fallback: parse uptime output using bash regex (avoids forks)
-        local uptime_out
-        uptime_out=$(uptime 2>/dev/null)
-        # Extract load averages from "load averages: 1.23 4.56 7.89"
-        if [[ "$uptime_out" =~ load\ averages?:\ ([0-9]+\.[0-9]+)\ ([0-9]+\.[0-9]+)\ ([0-9]+\.[0-9]+) ]]; then
-            one="${BASH_REMATCH[1]}"
-            five="${BASH_REMATCH[2]}"
-            fifteen="${BASH_REMATCH[3]}"
-        fi
-    fi
-    
-    _format_loadavg "$one" "$five" "$fifteen"
-}
-
-_get_load_value() {
-    # Get just the first load value for threshold comparison
-    local one five fifteen
-    
-    if is_macos; then
-        local sysctl_out
-        sysctl_out=$(sysctl -n vm.loadavg 2>/dev/null)
-        if [[ -n "$sysctl_out" ]]; then
-            read -r _ one five fifteen _ <<< "$sysctl_out"
-        fi
-    elif [[ -r /proc/loadavg ]]; then
-        read -r one five fifteen _ < /proc/loadavg
-    fi
-    
-    printf '%s' "${one:-0}"
+    printf '%s %s %s' "${one:-0}" "${five:-0}" "${fifteen:-0}"
 }
 
 # =============================================================================
@@ -197,26 +169,15 @@ _get_load_value() {
 # =============================================================================
 
 plugin_collect() {
-    local result num_cores load_value
-    
-    # Get CPU cores (cache for performance)
+    local num_cores load_raw one five fifteen result
     num_cores=$(_get_cpu_cores)
-    
-    # Get load average based on platform
-    if is_linux; then
-        result=$(_get_loadavg_linux)
-    elif is_macos; then
-        result=$(_get_loadavg_macos)
-    else
-        result="N/A"
-    fi
-    
-    # Get first load value for threshold comparison
-    load_value=$(_get_load_value)
-    
+    load_raw=$(_get_raw_loadavg)
+    read -r one five fifteen <<< "$load_raw"
+    result=$(_format_loadavg "$one" "$five" "$fifteen")
+
     plugin_data_set "result" "$result"
     plugin_data_set "num_cores" "$num_cores"
-    plugin_data_set "load_value" "$load_value"
+    plugin_data_set "load_value" "${one:-0}"
 }
 
 plugin_render() {

--- a/src/plugins/loadavg.sh
+++ b/src/plugins/loadavg.sh
@@ -87,8 +87,7 @@ plugin_get_health() {
 
     # Calculate thresholds (multiplied by cores, supporting float multipliers)
     local warn_th crit_th
-    warn_th=$(awk -v c="$num_cores" -v m="$warning_mult" 'BEGIN { printf "%.2f", c * m }')
-    crit_th=$(awk -v c="$num_cores" -v m="$critical_mult" 'BEGIN { printf "%.2f", c * m }')
+    read -r warn_th crit_th < <(awk -v c="$num_cores" -v w="$warning_mult" -v k="$critical_mult" 'BEGIN { printf "%.2f %.2f", c * w, c * k }')
 
     # Higher is worse - use float version for load average
     evaluate_threshold_health_float "${load:-0}" "$warn_th" "$crit_th"

--- a/src/plugins/memory.sh
+++ b/src/plugins/memory.sh
@@ -145,11 +145,12 @@ _collect_macos_vm_stat() {
     page_size=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
     mem_total=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
 
-    # vm_stat shows pages: active + wired = used
+    # vm_stat shows pages: active + wired + compressed = used
     pages_used=$(vm_stat 2>/dev/null | awk '
         /Pages active:/ {active = $3; gsub(/\./, "", active)}
         /Pages wired down:/ {wired = $4; gsub(/\./, "", wired)}
-        END {print (active + 0) + (wired + 0)}
+        /Pages occupied by compressor:/ {comp = $5; gsub(/\./, "", comp)}
+        END {print (active + 0) + (wired + 0) + (comp + 0)}
     ')
 
     [[ -z "$pages_used" ]] && return 1
@@ -172,14 +173,7 @@ _collect_macos() {
 _bytes_to_human() {
     local bytes="$1"
     bytes="${bytes:-0}"
-
-    local gb=$((bytes / 1073741824))
-
-    if [[ $gb -gt 0 ]]; then
-        awk -v b="$bytes" 'BEGIN {printf "%.1fG", b / 1073741824}'
-    else
-        awk -v b="$bytes" 'BEGIN {printf "%.0fM", b / 1048576}'
-    fi
+    format_bytes "$bytes" 1
 }
 
 # =============================================================================

--- a/src/plugins/microphone.sh
+++ b/src/plugins/microphone.sh
@@ -166,7 +166,7 @@ _detect_linux_usage() {
             # Filter out system processes and monitors
             local recording_apps
             recording_apps=$(echo "$source_outputs" | grep -E "(application\.name|State:)" |
-                            grep -B1 "State: RUNNING\|State: CORKED" |
+                            grep -B1 -E "State: (RUNNING|CORKED)" |
                             grep "application\.name" |
                             grep -viE "(PulseAudio|PipeWire|monitor|volume|meter)")
 

--- a/src/plugins/netspeed.sh
+++ b/src/plugins/netspeed.sh
@@ -46,9 +46,9 @@ plugin_declare_options() {
     declare_option "icon_download" "icon" $'\U000F01DA' "Icon for download"
     declare_option "icon_upload" "icon" $'\U000F0552' "Icon for upload"
 
-    # Thresholds (bytes/s, 0 = disabled)
-    declare_option "warning_threshold"  "number" "0" "Warning threshold (bytes/s, 0=disabled)"
-    declare_option "critical_threshold" "number" "0" "Critical threshold (bytes/s, 0=disabled)"
+    # Thresholds (KB/s, 0 = disabled)
+    declare_option "warning_threshold"  "number" "0" "Warning threshold (KB/s, 0=disabled)"
+    declare_option "critical_threshold" "number" "0" "Critical threshold (KB/s, 0=disabled)"
 
     # Cache
     declare_option "cache_ttl" "number" "2" "Cache duration in seconds"

--- a/src/plugins/nowplaying.sh
+++ b/src/plugins/nowplaying.sh
@@ -199,11 +199,6 @@ _get_nowplaying_linux() {
         done
     fi
 
-    local state_raw
-    state_raw=$(playerctl "${playerctl_args[@]}" status 2>/dev/null)
-    [[ -z "$state_raw" ]] && return 1
-    state="${state_raw,,}"  # Bash 4.0+ lowercase
-
     # When a priority list is configured, ignore every player that is
     # not in the list so the highest-priority one always wins.
     local app_priority
@@ -214,7 +209,7 @@ _get_nowplaying_linux() {
         local p
         for p in $app_priority; do
             p=$(trim "$p")
-            if playerctl "${playerctl_args[@]}" status --player "$p" 2>/dev/null | grep -qi .; then
+            if playerctl status --player "$p" 2>/dev/null | grep -qi .; then
                 priority_player="$p"
                 break
             fi
@@ -223,6 +218,11 @@ _get_nowplaying_linux() {
             playerctl_args+=("--player=$priority_player")
         fi
     fi
+
+    local state_raw
+    state_raw=$(playerctl "${playerctl_args[@]}" status 2>/dev/null)
+    [[ -z "$state_raw" ]] && return 1
+    state="${state_raw,,}"  # Bash 4.0+ lowercase
 
     # Get all metadata in one call using format string
     local metadata

--- a/src/plugins/packages.sh
+++ b/src/plugins/packages.sh
@@ -130,6 +130,7 @@ _invalidate_backend_cache() {
     local log_file="${_PKG_LOG_FILES[$backend]:-}"
 
     # brew / zb / port: use a directory mtime instead of a log file
+    local dir
     case "$backend" in
     brew)
         local brew_prefix
@@ -269,7 +270,7 @@ _count_updates_brew() {
         done
     fi
 
-    outdated=$(_timeout_pkg command brew "${brew_args[@]}" 2>/dev/null || echo '')
+    outdated=$(HOMEBREW_NO_AUTO_UPDATE=1 _timeout_pkg command brew "${brew_args[@]}" 2>/dev/null || echo '')
     if [[ -z "$outdated" ]]; then
         count=0
     else
@@ -308,9 +309,7 @@ _count_updates_apt() {
 
 _count_updates_dnf() {
     local count
-    count=$(_timeout_pkg command dnf check-update -q 2>/dev/null | grep -c . || echo 0)
-    # dnf adds header lines, subtract them
-    ((count > 3)) && count=$((count - 3)) || count=0
+    count=$(_timeout_pkg command dnf check-update -q 2>/dev/null | grep -c '^[^[:space:]]' || echo 0)
     printf '%s' "$count"
 }
 
@@ -495,8 +494,10 @@ plugin_collect() {
         if [[ -n "$sec_cached" ]]; then
             sec_count="$sec_cached"
         else
-            sec_count=$(_count_security_updates "$backend") || sec_count=""
-            [[ -n "$sec_count" ]] && cache_set "$sec_key" "$sec_count"
+            if ! sec_count=$(_count_security_updates "$backend"); then
+                sec_count="0"
+            fi
+            cache_set "$sec_key" "${sec_count:-0}"
         fi
         (( sec_total += ${sec_count:-0} ))
     done

--- a/src/plugins/ping.sh
+++ b/src/plugins/ping.sh
@@ -58,12 +58,20 @@ plugin_get_presence() { printf 'conditional'; }
 
 plugin_get_state() {
     local latency=$(plugin_data_get "latency")
-    [[ -n "$latency" && "$latency" != "-1" ]] && printf 'active' || printf 'inactive'
+    if [[ -z "$latency" || "$latency" == "-1" ]]; then
+        printf 'inactive'
+    else
+        printf 'active'
+    fi
 }
 
 plugin_get_health() {
     local latency warn_th crit_th
     latency=$(plugin_data_get "latency")
+    if [[ "$latency" == "-1" ]]; then
+        printf 'error'
+        return
+    fi
     warn_th=$(get_option "warning_threshold")
     crit_th=$(get_option "critical_threshold")
 
@@ -104,7 +112,7 @@ _get_ping_latency() {
 
     local result
     if is_macos; then
-        result=$(ping -c "$count" -t "$timeout" "$host" 2>/dev/null | tail -1)
+        result=$(ping -c "$count" -W "$((timeout * 1000))" "$host" 2>/dev/null | tail -1)
     else
         result=$(ping -c "$count" -W "$timeout" "$host" 2>/dev/null | tail -1)
     fi

--- a/src/plugins/pomodoro.sh
+++ b/src/plugins/pomodoro.sh
@@ -157,18 +157,31 @@ _clear_state() {
 
 _get_duration_for_phase() {
     local phase="$1"
+    local dur
     case "$phase" in
-    work) echo $(($(get_option "work_duration") * 60)) ;;
-    short_break) echo $(($(get_option "short_break") * 60)) ;;
-    long_break) echo $(($(get_option "long_break") * 60)) ;;
+    work)
+        dur=$(get_option "work_duration")
+        echo "$(( ${dur:-25} * 60 ))"
+        ;;
+    short_break)
+        dur=$(get_option "short_break")
+        echo "$(( ${dur:-5} * 60 ))"
+        ;;
+    long_break)
+        dur=$(get_option "long_break")
+        echo "$(( ${dur:-15} * 60 ))"
+        ;;
     *) echo 0 ;;
     esac
 }
 
 _should_long_break() {
-    local sessions="$1"
-    local sessions_before=$(get_option "sessions_before_long")
+    local sessions="${1:-0}"
+    local sessions_before
+    sessions_before=$(get_option "sessions_before_long")
+    sessions_before="${sessions_before:-4}"
 
+    (( sessions_before <= 0 )) && return 1
     [[ "$sessions" -gt 0 && $((sessions % sessions_before)) -eq 0 ]]
 }
 

--- a/src/plugins/smartkey.sh
+++ b/src/plugins/smartkey.sh
@@ -100,10 +100,14 @@ _check_gpg_card_prompt() {
 
         # Check if pinentry has TTY (interactive prompt active)
         [[ -d "/proc/$pinentry_pid/fd" ]] || return 1
-        # Use find instead of ls|grep to check for tty/pts file descriptors
-        find -L "/proc/$pinentry_pid/fd" -maxdepth 1 -type c 2>/dev/null | while read -r fd; do
-            [[ "$(readlink "$fd" 2>/dev/null)" =~ (tty|pts) ]] && exit 0
-        done && return 0
+        local has_tty=0
+        while read -r fd; do
+            if [[ "$(readlink "$fd" 2>/dev/null)" =~ (tty|pts) ]]; then
+                has_tty=1
+                break
+            fi
+        done < <(find -L "/proc/$pinentry_pid/fd" -maxdepth 1 -type c 2>/dev/null)
+        [[ "$has_tty" -eq 1 ]] && return 0
         return 1
     fi
 }
@@ -160,8 +164,17 @@ _check_scdaemon_signing() {
     # GETINFO scd_running returns quickly if not blocked
     # EPOCHREALTIME format: seconds.microseconds (e.g., 1704412800.123456)
     local start_us=${EPOCHREALTIME//./}
-    timeout 0.3 gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
-    local result_code=$?
+    local result_code
+    if has_cmd timeout; then
+        timeout 0.3 gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
+        result_code=$?
+    elif has_cmd gtimeout; then
+        gtimeout 0.3 gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
+        result_code=$?
+    else
+        gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
+        result_code=$?
+    fi
     local end_us=${EPOCHREALTIME//./}
 
     # If command timed out or took > 200ms, likely waiting for user

--- a/src/plugins/smartkey.sh
+++ b/src/plugins/smartkey.sh
@@ -164,17 +164,10 @@ _check_scdaemon_signing() {
     # GETINFO scd_running returns quickly if not blocked
     # EPOCHREALTIME format: seconds.microseconds (e.g., 1704412800.123456)
     local start_us=${EPOCHREALTIME//./}
-    local result_code
-    if has_cmd timeout; then
-        timeout 0.3 gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
-        result_code=$?
-    elif has_cmd gtimeout; then
-        gtimeout 0.3 gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
-        result_code=$?
-    else
-        gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
-        result_code=$?
-    fi
+    local timeout_cmd=""
+    has_cmd timeout && timeout_cmd="timeout 0.3" || { has_cmd gtimeout && timeout_cmd="gtimeout 0.3"; }
+    $timeout_cmd gpg-connect-agent "SCD GETINFO status" /bye &>/dev/null 2>&1
+    local result_code=$?
     local end_us=${EPOCHREALTIME//./}
 
     # If command timed out or took > 200ms, likely waiting for user

--- a/src/plugins/ssh.sh
+++ b/src/plugins/ssh.sh
@@ -67,6 +67,11 @@ _is_ssh_session() {
     # Check environment variables (fastest method)
     [[ -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" || -n "${SSH_CONNECTION:-}" ]] && return 0
 
+    # Also check tmux session/pane environment
+    local tmux_ssh
+    tmux_ssh=$(tmux show-environment SSH_CLIENT 2>/dev/null || tmux show-environment -g SSH_CLIENT 2>/dev/null)
+    [[ -n "$tmux_ssh" && "$tmux_ssh" != "-SSH_CLIENT" ]] && return 0
+
     # Check parent process
     local parent_cmd
     parent_cmd=$(ps -o comm= -p $PPID 2>/dev/null)
@@ -85,7 +90,7 @@ _is_ssh_in_pane() {
     local pid cmd
     for pid in $pane_pid $(pgrep -P "$pane_pid" 2>/dev/null); do
         cmd=$(ps -p "$pid" -o comm= 2>/dev/null)
-        [[ "$cmd" == "ssh" ]] && return 0
+        [[ "$(basename "$cmd")" == "ssh" ]] && return 0
     done
 
     return 1
@@ -100,7 +105,7 @@ _get_ssh_destination() {
     local pid cmd args dest
     for pid in $pane_pid $(pgrep -P "$pane_pid" 2>/dev/null); do
         cmd=$(ps -p "$pid" -o comm= 2>/dev/null)
-        if [[ "$cmd" == "ssh" ]]; then
+        if [[ "$(basename "$cmd")" == "ssh" ]]; then
             args=$(ps -p "$pid" -o args= 2>/dev/null)
             # Extract destination: skip flags (-X, -p 22, etc) and get user@host or host
             # Parse args to find the destination (first non-flag argument after 'ssh')

--- a/src/plugins/stocks.sh
+++ b/src/plugins/stocks.sh
@@ -227,30 +227,21 @@ _format_change() {
     local d1="${frac_part:0:1}"
     d1="${d1:-0}"
 
-    # Determine direction from sign and magnitude using integer math.
-    # Treat |change| >= 0.05 as movement; below that is flat.
-    local int_cmp=0
-    if ((${#frac_part} == 0)); then
-        int_cmp=$((10#$int_part))
-    else
-        # Compare |change| to 0.05 using integer cents: 5 cents = 0.05
-        local cents=$((10#${int_part:-0} * 100 + 10#${frac_part:0:2}))
-        ((${#frac_part} < 2)) && cents=$((cents * 10))
-        ((${#frac_part} > 2)) && cents=$((cents / 10 ** (${#frac_part} - 2)))
-        int_cmp=$cents
-    fi
+    # Determine direction from sign and magnitude using integer cents:
+    # 5 cents = 0.05% threshold; below that is flat.
+    local f2="${frac_part:0:2}"
+    [[ ${#f2} -eq 1 ]] && f2="${f2}0"
+    [[ ${#f2} -eq 0 ]] && f2="00"
+    local cents=$(( 10#${int_part:-0} * 100 + 10#$f2 ))
 
-    if [[ -n "$sign" ]]; then
-        # Original was negative; display as ↓ with magnitude (no sign prefix).
-        indicator="↓"
-        change="${int_part}.${d1}"
-    elif ((int_cmp > 5)); then
-        indicator="↑"
-        change="${int_part}.${d1}"
-    else
+    if (( cents <= 5 )); then
         indicator="→"
-        change="${int_part}.${d1}"
+    elif [[ -n "$sign" ]]; then
+        indicator="↓"
+    else
+        indicator="↑"
     fi
+    change="${int_part}.${d1}"
 
     printf '%s%s%%' "$indicator" "$change"
 }

--- a/src/plugins/swap.sh
+++ b/src/plugins/swap.sh
@@ -177,9 +177,9 @@ _to_bytes() {
     fi
 
     case "$unit" in
-    M) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 }' ;;
-    G) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 * 1024 }' ;;
-    T) awk -v v="$value" 'BEGIN { printf "%d", v * 1024 * 1024 * 1024 * 1024 }' ;;
+    M) awk -v v="$value" 'BEGIN { printf "%.0f", v * 1024 * 1024 }' ;;
+    G) awk -v v="$value" 'BEGIN { printf "%.0f", v * 1024 * 1024 * 1024 }' ;;
+    T) awk -v v="$value" 'BEGIN { printf "%.0f", v * 1024 * 1024 * 1024 * 1024 }' ;;
     *) echo "0" ;;
     esac
 }
@@ -228,22 +228,6 @@ plugin_collect() {
 
 plugin_get_content_type() { printf 'dynamic'; }
 plugin_get_presence() { printf 'conditional'; }
-
-# =============================================================================
-# Plugin Contract: Quick Context Check (Optional)
-# =============================================================================
-
-# Implement for quick validation of cached data relevance
-plugin_should_be_active() {
-    # Quick check if swap is still present
-    if is_macos; then
-        # Quick check for swap on macOS
-        sysctl -n vm.swapusage &>/dev/null || vm_stat &>/dev/null
-    else
-        # Quick check for swap on Linux
-        [[ -f /proc/meminfo ]] && grep -q "^SwapTotal:" /proc/meminfo 2>/dev/null
-    fi
-}
 
 # =============================================================================
 # Plugin Contract: State and Health

--- a/src/plugins/sysstatus.sh
+++ b/src/plugins/sysstatus.sh
@@ -184,7 +184,11 @@ _collect_temp_health() {
         # Linux: /sys/class/thermal/thermal_zone0/temp (millidegrees)
         if [[ -f /sys/class/thermal/thermal_zone0/temp ]]; then
             temp_c=$(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null)
-            temp_c=$((temp_c / 1000))
+            if [[ "$temp_c" =~ ^[0-9]+$ ]]; then
+                temp_c=$((temp_c / 1000))
+            else
+                temp_c=""
+            fi
         fi
     fi
 

--- a/src/plugins/temperature.sh
+++ b/src/plugins/temperature.sh
@@ -303,11 +303,11 @@ plugin_collect() {
         temp=$(_get_temp_macos "$source")
     fi
 
-    if [[ -n "$temp" && "$temp" =~ ^[0-9]+$ ]]; then
+    if [[ -n "$temp" && "$temp" =~ ^-?[0-9]+$ ]]; then
         plugin_data_set "temp_c" "$temp"
         plugin_data_set "available" "1"
     else
-        plugin_data_set "temp_c" "0"
+        plugin_data_set "temp_c" ""
         plugin_data_set "available" "0"
     fi
 }
@@ -329,9 +329,19 @@ plugin_get_presence() {
 # =============================================================================
 
 plugin_get_state() {
-    local available
+    local available temp_c hide_below
     available=$(plugin_data_get "available")
-    [[ "$available" == "1" ]] && printf 'active' || printf 'inactive'
+    [[ "$available" != "1" ]] && { printf 'inactive'; return; }
+
+    hide_below=$(get_option "hide_below_threshold")
+    if [[ -n "$hide_below" ]]; then
+        temp_c=$(plugin_data_get "temp_c")
+        if [[ -n "$temp_c" && "$temp_c" -lt "$hide_below" ]]; then
+            printf 'inactive'
+            return
+        fi
+    fi
+    printf 'active'
 }
 
 # =============================================================================
@@ -398,7 +408,7 @@ plugin_render() {
     show_unit=$(get_option "show_unit")
     hide_below=$(get_option "hide_below_threshold")
 
-    [[ -z "$temp_c" || "$temp_c" == "0" ]] && return
+    [[ -z "$temp_c" ]] && return
 
     # Convert thresholds if using Fahrenheit
     local display_temp="$temp_c"

--- a/src/plugins/terraform.sh
+++ b/src/plugins/terraform.sh
@@ -204,8 +204,10 @@ _detect_tool() {
 _is_tf_directory() {
     local path="$1"
     [[ -d "${path}/.terraform" ]] && return 0
-    ls "${path}"/*.tf &>/dev/null 2>&1 && return 0
-    ls "${path}"/terragrunt*.hcl &>/dev/null 2>&1 && return 0
+    local f
+    for f in "${path}"/*.tf "${path}"/terragrunt*.hcl; do
+        [[ -e "$f" ]] && return 0
+    done
     return 1
 }
 

--- a/src/plugins/topproc.sh
+++ b/src/plugins/topproc.sh
@@ -24,7 +24,7 @@ plugin_get_metadata() {
 
 plugin_check_dependencies() {
     # ps is POSIX - available on both macOS and Linux
-    has_cmd "ps" || return 1
+    require_cmd "ps" || return 1
     return 0
 }
 
@@ -87,14 +87,14 @@ plugin_collect() {
     
     # BSD/macOS and GNU ps both support -A -o %cpu,comm
     # macOS returns full path for some procs (e.g. /usr/sbin/coreaudiod), extract basename
-    result=$(ps -A -o %cpu,comm 2>/dev/null | awk 'NR>1 {print $1, $2}' | sort -rn | head -1)
+    result=$(ps -A -o %cpu,comm 2>/dev/null | sort -k1 -rn | head -1)
 
     if [[ -n "$result" ]]; then
-        local proc_pct proc_name
+        local proc_pct proc_cmd proc_name
+        read -r proc_pct proc_cmd <<< "$result"
 
-        # Parse: "87.5 /usr/sbin/coreaudiod" → proc_pct=87.5 proc_name=coreaudiod
-        proc_pct=$(echo "$result" | awk '{print $1}')
-        proc_name=$(echo "$result" | awk '{sub(/.*\//, "", $NF); print $NF}')
+        # Extract basename of process command
+        proc_name="${proc_cmd##*/}"
 
         # Truncate process name
         proc_name=$(truncate_text "$proc_name" "${max_length:-15}")

--- a/src/plugins/uptime.sh
+++ b/src/plugins/uptime.sh
@@ -57,22 +57,39 @@ plugin_collect() {
         # followed by an additional hh:mm at $6 and $7. Returning -1
         # on anything unparseable lets the caller fail collection so
         # the lifecycle can keep the previous record as stale.
-        uptime_seconds=$(uptime | awk -F'( |,|:)+' '
-            {
-                if ($5 == "min" || $5 == "mins") {
-                    print $4 * 60
-                } else if ($5 == "hrs") {
-                    print $4 * 3600
-                } else if ($5 == "day" || $5 == "days") {
-                    base = $4 * 86400
-                    if ($6 ~ /^[0-9]+$/ && $7 ~ /^[0-9]+$/) {
-                        base += ($6 * 3600) + ($7 * 60)
-                    }
-                    print base
-                } else {
-                    print -1
+        uptime_seconds=$(uptime 2>/dev/null | awk '{
+            sub(/^[[:space:]]+/, "")
+            up_idx = 0
+            for (i = 1; i <= NF; i++) {
+                if ($i == "up") {
+                    up_idx = i
+                    break
                 }
-            }')
+            }
+            if (!up_idx) { print -1; exit }
+            val = $(up_idx + 1)
+            unit = $(up_idx + 2)
+            gsub(/,/, "", val)
+            gsub(/,/, "", unit)
+
+            if (unit ~ /^min/) {
+                print val * 60
+            } else if (unit ~ /^hr/) {
+                print val * 3600
+            } else if (unit ~ /^day/) {
+                base = val * 86400
+                time_str = $(up_idx + 3)
+                gsub(/,/, "", time_str)
+                if (split(time_str, t, ":") == 2) {
+                    base += (t[1] * 3600) + (t[2] * 60)
+                }
+                print base
+            } else if (split(val, t, ":") == 2) {
+                print (t[1] * 3600) + (t[2] * 60)
+            } else {
+                print -1
+            }
+        }')
         if [[ "$uptime_seconds" == "-1" ]]; then
             return 1
         fi

--- a/src/plugins/volume.sh
+++ b/src/plugins/volume.sh
@@ -161,11 +161,11 @@ _is_muted_wpctl() {
 # =============================================================================
 
 _get_volume_pactl() {
-    pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null | grep -oP '\d+%' | head -1 | tr -d '%'
+    pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null | grep -oE '[0-9]+%' | head -1 | tr -d '%'
 }
 
 _is_muted_pactl() {
-    [[ "$(pactl get-sink-mute @DEFAULT_SINK@ 2>/dev/null | grep -oP 'yes|no')" == "yes" ]]
+    pactl get-sink-mute @DEFAULT_SINK@ 2>/dev/null | grep -q 'yes'
 }
 
 # =============================================================================
@@ -185,7 +185,7 @@ _is_muted_pamixer() {
 # =============================================================================
 
 _get_volume_amixer() {
-    amixer sget Master 2>/dev/null | grep -oP '\[\d+%\]' | head -1 | tr -d '[]%'
+    amixer sget Master 2>/dev/null | grep -oE '\[[0-9]+%\]' | head -1 | tr -d '[]%'
 }
 
 _is_muted_amixer() {
@@ -237,8 +237,13 @@ plugin_collect() {
     if [[ "$backend" == "macos" ]]; then
         local res
         res=$(osascript -e 'set s to get volume settings' -e '(output volume of s as text) & ":" & (output muted of s as text)' 2>/dev/null)
-        volume="${res%%:*}"
-        [[ "${res##*:}" == "true" ]] && muted=1 || muted=0
+        if [[ "$res" == *:* ]]; then
+            volume="${res%%:*}"
+            [[ "${res##*:}" == "true" ]] && muted=1 || muted=0
+        else
+            volume=$(_get_volume_macos)
+            _is_muted_macos && muted=1 || muted=0
+        fi
     else
         volume=$(_volume_get_percentage)
         _volume_is_muted && muted=1

--- a/src/plugins/volume.sh
+++ b/src/plugins/volume.sh
@@ -231,9 +231,18 @@ _volume_is_muted() {
 
 plugin_collect() {
     local volume muted=0
+    local backend
+    backend=$(_detect_audio_backend)
 
-    volume=$(_volume_get_percentage)
-    _volume_is_muted && muted=1
+    if [[ "$backend" == "macos" ]]; then
+        local res
+        res=$(osascript -e 'set s to get volume settings' -e '(output volume of s as text) & ":" & (output muted of s as text)' 2>/dev/null)
+        volume="${res%%:*}"
+        [[ "${res##*:}" == "true" ]] && muted=1 || muted=0
+    else
+        volume=$(_volume_get_percentage)
+        _volume_is_muted && muted=1
+    fi
 
     plugin_data_set "volume" "${volume:-0}"
     plugin_data_set "muted" "$muted"

--- a/src/plugins/vpn.sh
+++ b/src/plugins/vpn.sh
@@ -138,7 +138,7 @@ _detect_tailscale() {
 _detect_openvpn() {
     pgrep -x "openvpn" &>/dev/null || return 1
     local cfg name
-    cfg=$(pgrep -a openvpn 2>/dev/null | grep -o -- '--config [^ ]*' | head -1 | awk '{print $2}')
+    cfg=$(ps -eo args 2>/dev/null | grep '[o]penvpn' | grep -o -- '--config [^ ]*' | head -1 | awk '{print $2}')
     if [[ -n "$cfg" ]]; then
         name=$(basename "$cfg" .ovpn 2>/dev/null)
         [[ "$name" == "$cfg" ]] && name=$(basename "$cfg" .conf 2>/dev/null)

--- a/src/plugins/weather.sh
+++ b/src/plugins/weather.sh
@@ -574,27 +574,17 @@ _check_rate_limit() {
     local hour_bucket
     hour_bucket=$(date +"%Y%m%d%H")
     local cache_key="weather_rate_limit:${hour_bucket}"
-    local pending_key="weather_rate_pending:${hour_bucket}"
 
-    local current_count pending_count effective
+    local current_count
     current_count=$(cache_get "$cache_key" "3600") || current_count="0"
-    pending_count=$(cache_get "$pending_key" "120") || pending_count="0"
-    effective=$((current_count + pending_count))
 
     # Check if over limit
-    if ((effective >= max_per_hour)); then
-        log_debug "weather" "Rate limit exceeded: ${effective}/${max_per_hour}"
+    if ((current_count >= max_per_hour)); then
+        log_debug "weather" "Rate limit exceeded: ${current_count}/${max_per_hour}"
         return 1
     fi
 
-    # Reserve a slot. The reservation lives in a short-TTL cache so a
-    # crash mid-request still releases the slot within 2 minutes.
-    cache_set "$pending_key" "$((pending_count + 1))" "120"
-
-    # Also bump the persistent counter so the cap is observed even
-    # before the request returns. The release helper rolls it back if
-    # the request fails.
-    cache_set "$cache_key" "$((current_count + 1))" "3600"
+    cache_set "$cache_key" "$((current_count + 1))"
     return 0
 }
 
@@ -605,14 +595,11 @@ _release_rate_limit() {
     local hour_bucket
     hour_bucket=$(date +"%Y%m%d%H")
     local cache_key="weather_rate_limit:${hour_bucket}"
-    local pending_key="weather_rate_pending:${hour_bucket}"
 
-    local current_count pending_count
+    local current_count
     current_count=$(cache_get "$cache_key" "3600") || current_count="0"
-    pending_count=$(cache_get "$pending_key" "120") || pending_count="0"
 
-    ((current_count > 0)) && cache_set "$cache_key" "$((current_count - 1))" "3600"
-    ((pending_count > 0)) && cache_set "$pending_key" "$((pending_count - 1))" "120"
+    ((current_count > 0)) && cache_set "$cache_key" "$((current_count - 1))"
 }
 
 # =============================================================================

--- a/src/plugins/wifi.sh
+++ b/src/plugins/wifi.sh
@@ -76,17 +76,30 @@ plugin_declare_options() {
     declare_option "icon_disconnected" "icon" $'\U000F092E' "Disconnected icon"
 
     # Cache
-    declare_option "cache_ttl" "number" "5" "Cache duration in seconds"
+    declare_option "cache_ttl" "number" "15" "Cache duration in seconds"
 }
 
 # =============================================================================
 # macOS WiFi Detection - Multiple Methods
 # =============================================================================
 
+# Cache interface to avoid running networksetup -listallhardwareports on every cycle
+_POWERKIT_MACOS_WIFI_IFACE=""
+
+_get_wifi_macos_interface() {
+    if [[ -z "$_POWERKIT_MACOS_WIFI_IFACE" ]]; then
+        _POWERKIT_MACOS_WIFI_IFACE=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi|AirPort/{getline; print $2}')
+        _POWERKIT_MACOS_WIFI_IFACE="${_POWERKIT_MACOS_WIFI_IFACE:-en0}"
+    fi
+    printf '%s' "$_POWERKIT_MACOS_WIFI_IFACE"
+}
+
 # Method 1: ipconfig (fastest, requires Location Services)
 _get_wifi_macos_ipconfig() {
+    local iface
+    iface=$(_get_wifi_macos_interface)
     local ssid
-    ssid=$(ipconfig getsummary en0 2>/dev/null | awk '/ SSID :/{print $3}')
+    ssid=$(ipconfig getsummary "$iface" 2>/dev/null | awk '/ SSID :/{print $3}')
     [[ -n "$ssid" && "$ssid" != "<redacted>" && "$ssid" != *"redacted"* ]] && {
         printf '%s:75' "$ssid"
         return 0
@@ -94,31 +107,26 @@ _get_wifi_macos_ipconfig() {
     return 1
 }
 
-# Method 2: system_profiler (comprehensive, slower)
-_get_wifi_macos_system_profiler() {
-    local wifi_data
-    wifi_data=$(system_profiler SPAirPortDataType 2>/dev/null | awk '
-        /Status: Connected/ {connected = 1}
-        /Current Network Information:/ {if (connected) {getline; gsub(/^[[:space:]]+|:$/, ""); ssid = $0}}
-        /RSSI:/ {if (connected) {gsub(/[^-0-9]/, ""); rssi = $0}}
-        END {if (connected && ssid) print ssid ":" rssi; else exit 1}
-    ')
-    [[ -z "$wifi_data" ]] && return 1
+# Method 2: networksetup (fast, ~20ms, reliable across all macOS versions)
+_get_wifi_macos_networksetup() {
+    has_cmd networksetup || return 1
 
-    local ssid="${wifi_data%%:*}" rssi="${wifi_data##*:}"
-    [[ -z "$ssid" || "$ssid" == "<redacted>" || "$ssid" == *"redacted"* ]] && ssid="WiFi"
+    local wifi_interface
+    wifi_interface=$(_get_wifi_macos_interface)
 
-    # Convert RSSI to percentage (RSSI -100 = 0%, -50 = 100%)
-    local signal=75
-    if [[ -n "$rssi" && "$rssi" =~ ^-?[0-9]+$ ]]; then
-        signal=$(( (rssi + 100) * 100 / 50 ))
-        (( signal > 100 )) && signal=100
-        (( signal < 0 )) && signal=0
+    local output
+    output=$(networksetup -getairportnetwork "$wifi_interface" 2>/dev/null)
+    # Check for known disconnected / off states
+    if [[ -z "$output" ]] || [[ "$output" == *"not associated"* ]] || [[ "$output" == *"not turned on"* ]] || [[ "$output" == *"power is off"* ]]; then
+        return 1
     fi
-    printf '%s:%d' "$ssid" "$signal"
+
+    local ssid="${output#Current Wi-Fi Network: }"
+    [[ -z "$ssid" || "$ssid" == "$output" ]] && return 1
+    printf '%s:75' "$ssid"
 }
 
-# Method 3: airport utility (deprecated but reliable)
+# Method 3: airport utility (deprecated on modern macOS, fast if present)
 _get_wifi_macos_airport() {
     local airport="/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport"
     [[ -x "$airport" ]] || return 1
@@ -142,29 +150,35 @@ _get_wifi_macos_airport() {
     printf '%s:%d' "$ssid" "$signal_percent"
 }
 
-# Method 4: networksetup (fallback)
-_get_wifi_macos_networksetup() {
-    has_cmd networksetup || return 1
+# Method 4: system_profiler (slow, 7-10s; available for manual debug, omitted from hot polling)
+_get_wifi_macos_system_profiler() {
+    local wifi_data
+    wifi_data=$(system_profiler SPAirPortDataType 2>/dev/null | awk '
+        /Status: Connected/ {connected = 1}
+        /Current Network Information:/ {if (connected) {getline; gsub(/^[[:space:]]+|:$/, ""); ssid = $0}}
+        /RSSI:/ {if (connected) {gsub(/[^-0-9]/, ""); rssi = $0}}
+        END {if (connected && ssid) print ssid ":" rssi; else exit 1}
+    ')
+    [[ -z "$wifi_data" ]] && return 1
 
-    local wifi_interface
-    wifi_interface=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi|AirPort/{getline; print $2}')
-    [[ -z "$wifi_interface" ]] && wifi_interface="en0"
+    local ssid="${wifi_data%%:*}" rssi="${wifi_data##*:}"
+    [[ -z "$ssid" || "$ssid" == "<redacted>" || "$ssid" == *"redacted"* ]] && ssid="WiFi"
 
-    local output
-    output=$(networksetup -getairportnetwork "$wifi_interface" 2>/dev/null)
-    echo "$output" | grep -q "not associated" && return 1
-
-    local ssid="${output#Current Wi-Fi Network: }"
-    [[ -z "$ssid" ]] && return 1
-    printf '%s:75' "$ssid"
+    # Convert RSSI to percentage (RSSI -100 = 0%, -50 = 100%)
+    local signal=75
+    if [[ -n "$rssi" && "$rssi" =~ ^-?[0-9]+$ ]]; then
+        signal=$(( (rssi + 100) * 100 / 50 ))
+        (( signal > 100 )) && signal=100
+        (( signal < 0 )) && signal=0
+    fi
+    printf '%s:%d' "$ssid" "$signal"
 }
 
-# macOS entry point - try all methods
+# macOS entry point - try fast methods
 _get_wifi_macos() {
     _get_wifi_macos_ipconfig 2>/dev/null ||
-    _get_wifi_macos_system_profiler 2>/dev/null ||
-    _get_wifi_macos_airport 2>/dev/null ||
-    _get_wifi_macos_networksetup
+    _get_wifi_macos_networksetup 2>/dev/null ||
+    _get_wifi_macos_airport 2>/dev/null
 }
 
 # =============================================================================
@@ -253,12 +267,10 @@ _get_wifi_ip() {
     local ip=""
 
     if is_macos; then
-        ip=$(ipconfig getifaddr en0 2>/dev/null)
-        if [[ -z "$ip" ]]; then
-            local iface
-            iface=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi|AirPort/{getline; print $2}')
-            [[ -n "$iface" ]] && ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
-        fi
+        local iface
+        iface=$(_get_wifi_macos_interface)
+        ip=$(ipconfig getifaddr "$iface" 2>/dev/null)
+        [[ -z "$ip" && "$iface" != "en0" ]] && ip=$(ipconfig getifaddr en0 2>/dev/null)
     elif is_linux; then
         local iface
         has_cmd iw && iface=$(iw dev 2>/dev/null | awk '/Interface/{print $2}' | head -1)

--- a/src/plugins/wifi.sh
+++ b/src/plugins/wifi.sh
@@ -150,30 +150,6 @@ _get_wifi_macos_airport() {
     printf '%s:%d' "$ssid" "$signal_percent"
 }
 
-# Method 4: system_profiler (slow, 7-10s; available for manual debug, omitted from hot polling)
-_get_wifi_macos_system_profiler() {
-    local wifi_data
-    wifi_data=$(system_profiler SPAirPortDataType 2>/dev/null | awk '
-        /Status: Connected/ {connected = 1}
-        /Current Network Information:/ {if (connected) {getline; gsub(/^[[:space:]]+|:$/, ""); ssid = $0}}
-        /RSSI:/ {if (connected) {gsub(/[^-0-9]/, ""); rssi = $0}}
-        END {if (connected && ssid) print ssid ":" rssi; else exit 1}
-    ')
-    [[ -z "$wifi_data" ]] && return 1
-
-    local ssid="${wifi_data%%:*}" rssi="${wifi_data##*:}"
-    [[ -z "$ssid" || "$ssid" == "<redacted>" || "$ssid" == *"redacted"* ]] && ssid="WiFi"
-
-    # Convert RSSI to percentage (RSSI -100 = 0%, -50 = 100%)
-    local signal=75
-    if [[ -n "$rssi" && "$rssi" =~ ^-?[0-9]+$ ]]; then
-        signal=$(( (rssi + 100) * 100 / 50 ))
-        (( signal > 100 )) && signal=100
-        (( signal < 0 )) && signal=0
-    fi
-    printf '%s:%d' "$ssid" "$signal"
-}
-
 # macOS entry point - try fast methods
 _get_wifi_macos() {
     _get_wifi_macos_ipconfig 2>/dev/null ||

--- a/src/plugins/wifi.sh
+++ b/src/plugins/wifi.sh
@@ -99,7 +99,7 @@ _get_wifi_macos_ipconfig() {
     local iface
     iface=$(_get_wifi_macos_interface)
     local ssid
-    ssid=$(ipconfig getsummary "$iface" 2>/dev/null | awk '/ SSID :/{print $3}')
+    ssid=$(ipconfig getsummary "$iface" 2>/dev/null | awk -F': ' '/ SSID :/{print $2}')
     [[ -n "$ssid" && "$ssid" != "<redacted>" && "$ssid" != *"redacted"* ]] && {
         printf '%s:75' "$ssid"
         return 0
@@ -232,7 +232,7 @@ _get_wifi_linux_iwconfig() {
     has_cmd iwconfig || return 1
 
     local interface
-    interface=$(iwconfig 2>&1 | grep -o "^[a-zA-Z0-9]*" | head -1)
+    interface=$(iwconfig 2>/dev/null | grep 'IEEE 802.11' | awk '{print $1}' | head -1)
     [[ -z "$interface" ]] && return 1
 
     local info

--- a/src/plugins/yadm.sh
+++ b/src/plugins/yadm.sh
@@ -62,41 +62,44 @@ plugin_get_state() {
 }
 
 plugin_get_health() {
-    local ahead=$(plugin_data_get "ahead")
-    local modified=$(plugin_data_get "modified")
+    local ahead modified
+    ahead=$(plugin_data_get "ahead")
+    modified=$(plugin_data_get "modified")
 
     # Commits not pushed -> warning (needs attention)
-    [[ "$ahead" -gt 0 ]] && {
+    if (( ${ahead:-0} > 0 )); then
         printf 'warning'
         return
-    }
+    fi
     # Local modifications -> info (informational)
-    [[ "$modified" == "1" ]] && {
+    if [[ "$modified" == "1" ]]; then
         printf 'info'
         return
-    }
+    fi
     # Clean state
     printf 'ok'
 }
 
 plugin_get_context() {
-    local ahead=$(plugin_data_get "ahead")
-    local modified=$(plugin_data_get "modified")
+    local ahead modified
+    ahead=$(plugin_data_get "ahead")
+    modified=$(plugin_data_get "modified")
 
-    [[ "$ahead" -gt 0 ]] && {
+    if (( ${ahead:-0} > 0 )); then
         printf 'unpushed'
         return
-    }
-    [[ "$modified" == "1" ]] && {
+    fi
+    if [[ "$modified" == "1" ]]; then
         printf 'modified'
         return
-    }
+    fi
     printf 'clean'
 }
 
 plugin_get_icon() {
-    local context=$(plugin_get_context)
-    [[ "$context" == "modified" ]] && get_option "icon_modified" || get_option "icon"
+    local modified
+    modified=$(plugin_data_get "modified")
+    [[ "$modified" == "1" ]] && get_option "icon_modified" || get_option "icon"
 }
 
 # =============================================================================

--- a/src/renderer/renderer.sh
+++ b/src/renderer/renderer.sh
@@ -46,9 +46,7 @@ configure_status_bar() {
     # Refresh interval (relaxed on battery to conserve power)
     local interval
     interval=$(get_tmux_option "@powerkit_status_interval" "${POWERKIT_DEFAULT_STATUS_INTERVAL}")
-    local battery_saver
-    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
-    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+    if is_battery_saver_active; then
         (( interval < 10 )) && interval=10
     fi
     tmux set-option -g status-interval "$interval"

--- a/src/renderer/renderer.sh
+++ b/src/renderer/renderer.sh
@@ -43,9 +43,14 @@ configure_status_bar() {
     status_style=$(build_status_style)
     tmux set-option -g status-style "$status_style"
 
-    # Refresh interval
+    # Refresh interval (relaxed on battery to conserve power)
     local interval
     interval=$(get_tmux_option "@powerkit_status_interval" "${POWERKIT_DEFAULT_STATUS_INTERVAL}")
+    local battery_saver
+    battery_saver=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}")
+    if [[ "$battery_saver" == "on" ]] || { [[ "$battery_saver" == "auto" ]] && is_on_battery; }; then
+        (( interval < 10 )) && interval=10
+    fi
     tmux set-option -g status-interval "$interval"
 
     # Status bar lengths - ensure enough space for plugins and session

--- a/src/renderer/styles.sh
+++ b/src/renderer/styles.sh
@@ -83,7 +83,7 @@ build_message_command_style() {
 # Returns: color value
 build_clock_format() {
     local color
-    color=$(resolve_color "#c0caf5")
+    color=$(resolve_color "session-fg")
 
     printf '%s' "$color"
 }

--- a/src/utils/api.sh
+++ b/src/utils/api.sh
@@ -148,7 +148,7 @@ api_fetch_with_basic_config() {
     local cfg
     cfg=$(mktemp "${TMPDIR:-/tmp}/powerkit-curl.XXXXXX") || return 1
     chmod 600 "$cfg"
-    trap 'rm -f "$cfg"' RETURN
+    trap 'rm -f "${cfg:-}" 2>/dev/null; trap - RETURN' RETURN
     printf -- '-u %s:%s\n' "$user" "$password" >"$cfg"
     curl -sf --config "$cfg" --connect-timeout "$timeout" --max-time "$((timeout * 2))" \
         "$url" 2>/dev/null

--- a/src/utils/keybinding.sh
+++ b/src/utils/keybinding.sh
@@ -50,7 +50,7 @@ _check_and_log_conflict() {
 
     # Check if this key is already bound
     local existing_binding
-    existing_binding=$(tmux list-keys -T prefix 2>/dev/null | grep "bind-key.*-T prefix.*$key " || true)
+    existing_binding=$(tmux list-keys -T prefix 2>/dev/null | awk -v k="$key" '$1=="bind-key" && $3=="prefix" && $4==k {print; exit}' || true)
 
     [[ -z "$existing_binding" ]] && return 0
 
@@ -558,48 +558,21 @@ pk_popup_delayed() {
     # Run popup in background with delay
     # Wait for a client to be attached before showing the popup
     # This handles the case where PowerKit starts during detached session creation
-    # Sanitize all interpolated values with printf %q
-    local safe_delay safe_width safe_height safe_command
-    safe_delay=$(printf '%q' "$delay")
-    safe_width=$(printf '%q' "$width")
-    safe_height=$(printf '%q' "$height")
-    safe_command=$(printf '%q' "$command")
-
-    local popup_script
-    popup_script=$(
-        cat <<'SCRIPT_EOF'
-delay=DELAY_PLACEHOLDER
-width="WIDTH_PLACEHOLDER"
-height="HEIGHT_PLACEHOLDER"
-command="COMMAND_PLACEHOLDER"
-
-# Wait for initial delay
+    local script='
+delay="$1"; width="$2"; height="$3"; command="$4"
 sleep "$delay"
-
-# Wait up to 30 seconds for a client to attach
 max_wait=30
 waited=0
 while [[ $waited -lt $max_wait ]]; do
     if tmux list-clients 2>/dev/null | grep -q .; then
-        # Client found, show popup
         tmux display-popup -E $width $height "$command"
         exit 0
     fi
     sleep 1
     ((waited++))
 done
-# No client attached after timeout, skip popup silently
-SCRIPT_EOF
-    )
-
-    # Substitute placeholders with sanitized values
-    popup_script="${popup_script//DELAY_PLACEHOLDER/$safe_delay}"
-    popup_script="${popup_script//WIDTH_PLACEHOLDER/$safe_width}"
-    popup_script="${popup_script//HEIGHT_PLACEHOLDER/$safe_height}"
-    popup_script="${popup_script//COMMAND_PLACEHOLDER/$safe_command}"
-
-    # Execute via bash
-    tmux run-shell -b "bash -c '$popup_script'" 2>/dev/null || true
+'
+    tmux run-shell -b "$(printf 'bash -c %q bash %q %q %q %q' "$script" "$delay" "$width" "$height" "$command")" 2>/dev/null || true
 }
 
 # =============================================================================

--- a/src/utils/numbers.sh
+++ b/src/utils/numbers.sh
@@ -197,37 +197,6 @@ format_bytes() {
 }
 
 # Internal: render scaled bytes with N decimals + suffix.
-# Pure bash for precision in {0,1,2}; uses int/frac decomposition.
-_format_byte_scaled() {
-    local bytes="$1" divisor="$2" precision="$3" suffix="$4"
-    local int_part=$((bytes / divisor))
-    local frac=$(((bytes % divisor) * 100 / divisor)) # 2-decimal residual
-
-    if ((precision == 0)); then
-        printf '%d%s' "$int_part" "$suffix"
-        return
-    fi
-
-    # Round frac to "precision" decimals.
-    local carry=0
-    if ((precision == 1)); then
-        # Look at the second decimal: round up if >=5.
-        local second=$(((bytes % divisor) * 100 % divisor * 10 / divisor))
-        ((second >= 5)) && carry=1
-        frac=$(((bytes % divisor) * 10 / divisor)) # 1-decimal frac
-    fi
-    int_part=$((int_part + carry))
-
-    printf '%d.' "$int_part"
-    if ((precision == 1)); then
-        printf '%d' "$frac"
-    elif ((precision == 2)); then
-        printf '%02d' "$frac"
-    fi
-    printf '%s' "$suffix"
-}
-
-# Internal: render scaled bytes with N decimals + suffix.
 # Usage: _format_byte_scaled <bytes> <divisor> <precision> <suffix>
 # Avoids multiplication overflow by scaling in chunks when bytes is huge.
 _format_byte_scaled() {

--- a/src/utils/platform.sh
+++ b/src/utils/platform.sh
@@ -558,3 +558,11 @@ is_on_battery() {
     [[ "$_CACHED_POWER_STATE" == "battery" ]]
 }
 
+# Check if battery saver mode is active (based on @powerkit_battery_saver and battery status)
+# Usage: is_battery_saver_active && ...
+is_battery_saver_active() {
+    local mode
+    mode=$(get_tmux_option "@powerkit_battery_saver" "${POWERKIT_DEFAULT_BATTERY_SAVER:-auto}" 2>/dev/null || echo "auto")
+    [[ "$mode" == "on" ]] || { [[ "$mode" == "auto" ]] && is_on_battery; }
+}
+

--- a/src/utils/platform.sh
+++ b/src/utils/platform.sh
@@ -506,3 +506,55 @@ get_os_icon() {
             ;;
     esac
 }
+
+# =============================================================================
+# Power Source Detection
+# =============================================================================
+
+declare -g _CACHED_POWER_STATE=""
+declare -g _CACHED_POWER_TIME=0
+
+# Check if system is currently running on battery power
+# Cached for 15 seconds to avoid repeated hardware/system queries
+# Usage: is_on_battery && echo "battery" || echo "ac"
+is_on_battery() {
+    local now="${EPOCHSECONDS:-$(date +%s)}"
+    if (( now - _CACHED_POWER_TIME < 15 )) && [[ -n "$_CACHED_POWER_STATE" ]]; then
+        [[ "$_CACHED_POWER_STATE" == "battery" ]]
+        return
+    fi
+
+    _CACHED_POWER_TIME="$now"
+    _CACHED_POWER_STATE="ac"
+
+    if is_macos; then
+        local batt_out
+        batt_out=$(pmset -g batt 2>/dev/null)
+        if [[ "$batt_out" == *"Battery Power"* ]]; then
+            _CACHED_POWER_STATE="battery"
+        fi
+    elif is_linux; then
+        local ac_online=0
+        local ac
+        for ac in /sys/class/power_supply/AC* /sys/class/power_supply/ADP* /sys/class/power_supply/mains; do
+            if [[ -f "$ac/online" ]]; then
+                if [[ "$(<"$ac/online")" == "1" ]]; then
+                    ac_online=1
+                    break
+                fi
+            fi
+        done
+        if (( ac_online == 0 )); then
+            local bat
+            for bat in /sys/class/power_supply/BAT*; do
+                if [[ -f "$bat/status" && "$(<"$bat/status")" == "Discharging" ]]; then
+                    _CACHED_POWER_STATE="battery"
+                    break
+                fi
+            done
+        fi
+    fi
+
+    [[ "$_CACHED_POWER_STATE" == "battery" ]]
+}
+

--- a/src/utils/strings.sh
+++ b/src/utils/strings.sh
@@ -163,8 +163,7 @@ to_upper() {
 # Capitalize first letter
 # Usage: capitalize "hello world"  # Returns "Hello world"
 capitalize() {
-    local text="$1"
-    printf '%s%s' "${text:0:1}" "${text:1}" | { read -r first rest; printf '%s%s' "${first^}" "$rest"; }
+    printf '%s' "${1^}"
 }
 
 # =============================================================================

--- a/src/utils/time.sh
+++ b/src/utils/time.sh
@@ -18,11 +18,11 @@ time_iso_start() {
     else
         ts=$((EPOCHSECONDS - days * 86400))
     fi
-    printf '%(%Y-%m-%dT%H:%M:%SZ)T' "$ts"
+    TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' "$ts"
 }
 
 # Print ISO-8601 Zulu timestamp for "now".
-time_iso_now() { printf '%(%Y-%m-%dT%H:%M:%SZ)T' "$EPOCHSECONDS"; }
+time_iso_now() { TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' "$EPOCHSECONDS"; }
 
 # Print Unix epoch seconds `days` days in the past.
 # Usage: time_epoch_start [days_in_past]

--- a/src/utils/ui_backend.sh
+++ b/src/utils/ui_backend.sh
@@ -738,8 +738,10 @@ ui_toast_popup() {
 
     [[ -z "$message" ]] && return 0
 
+    local safe_msg
+    safe_msg=$(printf '%q' "$message")
     tmux display-popup -E -w "$width" -h "$height" \
-        "printf '%s\n\nPress any key...' '$message'; read -rsn1"
+        "printf '%s\n\nPress any key...\n' $safe_msg; read -rsn1"
 }
 
 # Display toast notification (convenience wrapper)


### PR DESCRIPTION
Replaces single-backend detection with a multi-backend aggregation model
that detects all available package managers and sums their update counts.

New backends (11):
  - zb (zerobrew) - macOS Homebrew-compatible alternative
  - nix-env - NixOS and any platform using Nix
  - mise - cross-platform tool version manager
  - flatpak - Linux Flatpak store
  - zypper - openSUSE/SLES
  - emerge - Gentoo (prefers eix for performance, falls back to emerge -p)
  - apk - Alpine Linux
  - pkg - FreeBSD
  - snap - Ubuntu Snap Store
  - pamac - Manjaro (AUR/pacman frontend)
  - port - macOS MacPorts

Architecture changes:
  - _detect_backend() replaced by _detect_backends() (space-separated list)
  - Cache keys are now per-backend: packages_updates_<backend>
  - _invalidate_if_upgraded() iterates over all backends individually
  - Cache invalidation extended to zb (/opt/zerobrew) and port (/opt/local)
  - Security update counts aggregated across all supporting backends

New option:
  - backends (string): explicit comma-separated list, e.g. 'brew,zb'
    Overrides the legacy 'backend' enum option when set.

Behavior in auto mode (breaking):
  Previously stopped at the first detected package manager.
  Now detects ALL available managers and shows the summed total.
  Legacy single-backend mode preserved via: set -g @powerkit_packages_backend brew## Summary