### PR TITLE
fix(git): scope status data to active pane

### DIFF
--- a/bin/powerkit-render
+++ b/bin/powerkit-render
@@ -198,6 +198,7 @@ _render_background() {
         # Render and cache using cache_set (cache_key includes theme for invalidation)
         output=$(render_plugins "$side")
         cache_set "$cache_key" "$output"
+        tmux refresh-client -S 2>/dev/null || true
     ' _ "$POWERKIT_ROOT" "$side" "$cache_key" "$lock_token" "$lock_dir" &>/dev/null &
     disown
 }

--- a/bin/powerkit-render
+++ b/bin/powerkit-render
@@ -34,10 +34,18 @@ _batch_load_tmux_options
 # Cache key for rendered output (includes theme to invalidate on theme change)
 _render_cache_key() {
     local side="${1:-right}"
-    local theme variant
+    local theme variant pane session scope
     printf -v theme '%s' "$(get_tmux_option "@powerkit_theme" "${POWERKIT_DEFAULT_THEME}")"
     printf -v variant '%s' "$(get_tmux_option "@powerkit_theme_variant" "${POWERKIT_DEFAULT_THEME_VARIANT}")"
-    printf 'rendered_%s__%s__%s' "$side" "$theme" "$variant"
+    pane="${POWERKIT_PANE:-}"
+    session="${POWERKIT_SESSION:-}"
+    scope=""
+    if [[ -n "$pane" && "$pane" != "#{pane_id}" ]]; then
+        scope="__p${pane#%}"
+    elif [[ -n "$session" && "$session" != "#{session_name}" ]]; then
+        scope="__s${session}"
+    fi
+    printf 'rendered_%s__%s__%s%s' "$side" "$theme" "$variant" "$scope"
 }
 
 # TTL for render cache (matches status-interval and adapts to battery saver)
@@ -51,7 +59,14 @@ _get_render_cache_ttl() {
 }
 
 _render_lock_dir() {
-    printf '%s/.render_lock' "$_CACHE_DIR"
+    local pane="${POWERKIT_PANE:-}"
+    local session=""
+    if [[ -n "$pane" && "$pane" != "#{pane_id}" ]]; then
+        session="__p${pane#%}"
+    elif [[ -n "${POWERKIT_SESSION:-}" && "${POWERKIT_SESSION:-}" != "#{session_name}" ]]; then
+        session="__s${POWERKIT_SESSION}"
+    fi
+    printf '%s/.render_lock%s' "$_CACHE_DIR" "$session"
 }
 
 # Check if render is already in progress (uses directory as atomic lock)
@@ -151,17 +166,18 @@ _render_background() {
     local side="$1"
     local cache_key="$2"
     local lock_token="$3"
+    local lock_dir="$4"
 
     bash -c '
         POWERKIT_ROOT="$1"
         side="$2"
         cache_key="$3"
         lock_token="$4"
+        lock_dir="$5"
         export POWERKIT_ROOT
 
         # Cleanup lock on exit
         cleanup_lock() {
-            local lock_dir="${_CACHE_DIR}/.render_lock"
             [[ -f "${lock_dir}/owner" && $(<"${lock_dir}/owner") == *":${lock_token}" ]] || return 0
             rm -f "${lock_dir}/owner"
             rmdir "$lock_dir" 2>/dev/null || true
@@ -171,7 +187,6 @@ _render_background() {
 
         # Source and render
         . "${POWERKIT_ROOT}/src/core/bootstrap.sh"
-        lock_dir="${_CACHE_DIR}/.render_lock"
         [[ -f "${lock_dir}/owner" && $(<"${lock_dir}/owner") == *":${lock_token}" ]] && \
             printf "%s:%s:%s" "$$" "$EPOCHSECONDS" "$lock_token" >"${lock_dir}/owner"
         load_powerkit_theme
@@ -183,7 +198,7 @@ _render_background() {
         # Render and cache using cache_set (cache_key includes theme for invalidation)
         output=$(render_plugins "$side")
         cache_set "$cache_key" "$output"
-    ' _ "$POWERKIT_ROOT" "$side" "$cache_key" "$lock_token" &>/dev/null &
+    ' _ "$POWERKIT_ROOT" "$side" "$cache_key" "$lock_token" "$lock_dir" &>/dev/null &
     disown
 }
 
@@ -217,7 +232,7 @@ fi
 # Start background render only when this process owns the atomic lock.
 lock_token="$$.${RANDOM}"
 if _acquire_render_lock "$lock_token"; then
-    _render_background "$side" "$cache_key" "$lock_token"
+    _render_background "$side" "$cache_key" "$lock_token" "$(_render_lock_dir)"
 fi
 
 # Return stale cache if exists, otherwise loading

--- a/src/core/cache.sh
+++ b/src/core/cache.sh
@@ -301,8 +301,46 @@ cache_clear_all() {
 # Get plugin cache key
 # Usage: _plugin_cache_key "plugin_name"
 _plugin_cache_key() {
+    _plugin_data_cache_key "$1"
+}
+
+# Get plugin data cache key
+# Usage: _plugin_data_cache_key "plugin_name"
+_plugin_data_cache_key() {
+    _plugin_scoped_cache_key "$1" "data"
+}
+
+# Get plugin ttl cache key
+# Usage: _plugin_ttl_cache_key "plugin_name"
+_plugin_ttl_cache_key() {
+    _plugin_scoped_cache_key "$1" "ttl"
+}
+
+# Scope pane-context plugins to a pane so cached data cannot leak between panes.
+# POWERKIT_PANE is injected by the status line using #{pane_id}.
+# Usage: _plugin_scoped_cache_key "plugin_name" "suffix"
+_plugin_scoped_cache_key() {
     local plugin="$1"
-    printf 'plugin_%s' "$plugin"
+    local suffix="$2"
+    case "$plugin" in
+        git|terraform)
+            local pane="${POWERKIT_PANE:-}"
+            local session="${POWERKIT_SESSION:-}"
+            if [[ -n "$pane" && "$pane" != "#{pane_id}" ]]; then
+                printf 'plugin_%s_%s_%s' "$plugin" "${pane#%}" "$suffix"
+                return
+            fi
+            if [[ "$plugin" == "git" ]]; then
+                printf 'plugin_%s_no_target_%s' "$plugin" "$suffix"
+                return
+            fi
+            if [[ -n "$session" && "$session" != "#{session_name}" ]]; then
+                printf 'plugin_%s_%s_%s' "$plugin" "$session" "$suffix"
+                return
+            fi
+            ;;
+    esac
+    printf 'plugin_%s_%s' "$plugin" "$suffix"
 }
 
 # Store plugin output in cache

--- a/src/core/lifecycle.sh
+++ b/src/core/lifecycle.sh
@@ -595,8 +595,8 @@ _spawn_plugin_refresh() {
 
         # Check dependencies
         if declare -F plugin_check_dependencies &>/dev/null && ! plugin_check_dependencies; then
-            cache_set "plugin_${name}_data" "HIDDEN"
-            cache_set "plugin_${name}_ttl" "${_DEFAULT_CACHE_TTL_LONG:-3600}"
+            cache_set "$(_plugin_data_cache_key "$name")" "HIDDEN"
+            cache_set "$(_plugin_ttl_cache_key "$name")" "${_DEFAULT_CACHE_TTL_LONG:-3600}"
             exit 0
         fi
 
@@ -610,7 +610,7 @@ _spawn_plugin_refresh() {
         # Check visibility using unified helper
         presence=$(plugin_get_presence)
         if is_plugin_hidden_by_presence "$presence" "$state"; then
-            cache_set "plugin_${name}_data" "HIDDEN"
+            cache_set "$(_plugin_data_cache_key "$name")" "HIDDEN"
             exit 0
         fi
 
@@ -635,11 +635,11 @@ _spawn_plugin_refresh() {
 
         output=$(_build_plugin_output "$icon" "$content" "$state" "$health")
 
-        cache_set "plugin_${name}_data" "$output"
+        cache_set "$(_plugin_data_cache_key "$name")" "$output"
 
         # Cache TTL
         ttl=$(_get_plugin_cache_ttl)
-        cache_set "plugin_${name}_ttl" "$ttl"
+        cache_set "$(_plugin_ttl_cache_key "$name")" "$ttl"
     ' _ "$name" "$lock_dir" "$POWERKIT_ROOT" &>/dev/null &
     disown
 }
@@ -792,8 +792,8 @@ collect_plugin_render_data() {
     _set_plugin_context "$name"
 
     # Cache keys
-    local cache_key="plugin_${name}_data"
-    local ttl_cache_key="plugin_${name}_ttl"
+    local cache_key="$(_plugin_data_cache_key "$name")"
+    local ttl_cache_key="$(_plugin_ttl_cache_key "$name")"
 
     # Get TTL (use cached value to avoid sourcing plugin just for TTL)
     local ttl

--- a/src/plugins/git.sh
+++ b/src/plugins/git.sh
@@ -9,6 +9,14 @@
 POWERKIT_ROOT="${POWERKIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 . "${POWERKIT_ROOT}/src/contract/plugin_contract.sh"
 
+_powerkit_git_active_pane_path() {
+    local pane path
+    pane="${POWERKIT_PANE:-}"
+    [[ -z "$pane" || "$pane" == "#{pane_id}" ]] && return
+    path=$(tmux display-message -p -t "$pane" '#{pane_current_path}' 2>/dev/null)
+    printf '%s' "$path"
+}
+
 # =============================================================================
 # Plugin Contract: Metadata
 # =============================================================================
@@ -57,7 +65,7 @@ plugin_get_presence() { printf 'conditional'; }
 # disappears immediately when switching to a non-git directory
 plugin_should_be_active() {
     local path
-    path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+    path=$(_powerkit_git_active_pane_path)
     [[ -n "$path" ]] && git -C "$path" rev-parse --is-inside-work-tree &>/dev/null
 }
 
@@ -120,7 +128,8 @@ plugin_get_icon() {
 # =============================================================================
 
 plugin_collect() {
-    local path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+    local path
+    path=$(_powerkit_git_active_pane_path)
     [[ -z "$path" || ! -d "$path" ]] && return
 
     # Check if inside a git repository

--- a/src/plugins/terraform.sh
+++ b/src/plugins/terraform.sh
@@ -86,8 +86,13 @@ plugin_get_presence() { printf 'conditional'; }
 # This is called BEFORE returning cached data to ensure the plugin
 # disappears immediately when switching to a non-Terraform directory
 plugin_should_be_active() {
-    local path
-    path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+    local pane path
+    pane="${POWERKIT_PANE:-}"
+    if [[ -n "$pane" && "$pane" != "#{pane_id}" ]]; then
+        path=$(tmux display-message -p -t "$pane" '#{pane_current_path}' 2>/dev/null)
+    else
+        path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+    fi
     [[ -n "$path" && -d "$path" ]] && _is_tf_directory "$path"
 }
 
@@ -245,7 +250,10 @@ _get_terraform_workspace() {
 }
 
 plugin_collect() {
-    local path=$(tmux display-message -p '#{pane_current_path}' 2>/dev/null)
+    local pane path
+    pane="${POWERKIT_PANE:-}"
+    [[ -z "$pane" || "$pane" == "#{pane_id}" ]] && return 0
+    path=$(tmux display-message -p -t "$pane" '#{pane_current_path}' 2>/dev/null)
     [[ -z "$path" || ! -d "$path" ]] && return 0
 
     # Only show in Terraform directories
@@ -294,4 +302,3 @@ plugin_setup_keybindings() {
     # terraform_workspace_selector uses display-menu (not popup)
     pk_bind_shell "$ws_key" "bash '$helper_script' select" "terraform:workspace"
 }
-

--- a/src/renderer/entities/plugins.sh
+++ b/src/renderer/entities/plugins.sh
@@ -29,7 +29,7 @@ plugins_render() {
     local side="${1:-right}"
 
     # Pass side to powerkit-render so it knows which direction separators should point
-    printf '#(%s %s)' "${POWERKIT_ROOT}/bin/powerkit-render" "$side"
+    printf '#(POWERKIT_SESSION=#{session_name} POWERKIT_PANE=#{pane_id} %s %s)' "${POWERKIT_ROOT}/bin/powerkit-render" "$side"
 }
 
 # Get the background color of plugins


### PR DESCRIPTION
## Summary

Fixes the git status segment showing a branch from another tmux window or session when the active pane is not inside a Git repository.

## Root Cause

PowerKit rendered status data using tmux's session-level current window. With multiple clients or windows, that target could resolve to a different pane. Shared render and plugin caches then allowed that incorrect branch to remain visible.

## Changes

- Pass `#{pane_id}` from the tmux status format into `powerkit-render`.
- Resolve Git context and collection against that exact pane.
- Fail closed when no valid pane target is available.
- Scope Git and Terraform plugin caches to the pane.
- Scope rendered output caches and render locks to the pane.
- Apply the same exact-pane targeting to Terraform context collection.

## Verification

- Bash syntax validation: 207 passed.
- Contract validation: 131 passed.
- Manual behavior check: pane without a repository hides Git; pane with a repository shows Git.
- `git diff --check`: passed.

